### PR TITLE
ci: also upload binaries artifact on main pushes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,11 +124,16 @@ jobs:
   binaries:
     name: binaries
     # Cross-compile the binary for linux/darwin x amd64/arm64 and upload
-    # the resulting tar.gz archives + SHA256SUMS as a workflow artifact
-    # so reviewers can grab a build of the PR without checking out and
-    # rebuilding locally. PR-only -- main pushes don't need this because
-    # consumers there pull the GHCR image instead.
-    if: github.event_name == 'pull_request'
+    # the resulting tar.gz archives + SHA256SUMS as a workflow artifact:
+    #
+    #   - on PR:        binaries-pr-<number>      (7d retention)
+    #   - on main push: binaries-main-<short_sha> (30d retention)
+    #
+    # On PRs the artifact lets reviewers grab a build without checking
+    # out and rebuilding locally. On main, it complements the GHCR
+    # `:edge` / `:main-<sha>` images for users who deploy bare binaries
+    # rather than containers (e.g. systemd hosts), giving them a stable
+    # download URL between tagged releases.
     needs: go
     runs-on: ubuntu-latest
     steps:
@@ -151,15 +156,30 @@ jobs:
       - name: just release-binaries
         run: just release-binaries
 
+      # Pick a name + retention that reflects the trigger so PR and main
+      # artifacts don't collide and main builds stick around long enough
+      # to be useful between tagged releases.
+      - name: Resolve artifact name
+        id: artifact
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "name=binaries-pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "retention=7" >> "$GITHUB_OUTPUT"
+          else
+            short_sha=$(echo "${{ github.sha }}" | cut -c1-7)
+            echo "name=binaries-main-$short_sha" >> "$GITHUB_OUTPUT"
+            echo "retention=30" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload binaries artifact
         uses: actions/upload-artifact@v7
         with:
-          name: binaries-pr-${{ github.event.pull_request.number }}
+          name: ${{ steps.artifact.outputs.name }}
           path: |
             dist/url-shortener_*.tar.gz
             dist/SHA256SUMS
           if-no-files-found: error
-          retention-days: 7
+          retention-days: ${{ steps.artifact.outputs.retention }}
 
   image:
     name: docker image

--- a/README.md
+++ b/README.md
@@ -252,13 +252,21 @@ can pull the bleeding edge without waiting for a release tag:
 | `:edge` | every push to `main` | floating dev pointer |
 | `:main-<short_sha>` | every push to `main` | pin to a specific commit |
 
+Each push to `main` also uploads a binaries artifact to the workflow
+run for users who deploy the binary directly rather than the image:
+
+- `binaries-main-<short_sha>` -- `url-shortener_<version>_<os>_<arch>.tar.gz`
+  for `linux`/`darwin` x `amd64`/`arm64`, plus `SHA256SUMS`. 30-day
+  retention, indexed by the same short-sha as the matching `:main-<short_sha>`
+  image so the two stay in lockstep.
+
 Pull-request runs do **not** push to GHCR. Instead they upload two
 artifacts to the workflow run that you can grab from the Actions UI:
 
 - `binaries-pr-<N>` -- `url-shortener_<version>_<os>_<arch>.tar.gz`
-  for all four platforms, plus `SHA256SUMS`.
+  for all four platforms, plus `SHA256SUMS`. 7-day retention.
 - `oci-image-pr-<N>` -- a single multi-arch OCI tarball; load it with
-  `docker load -i url-shortener-oci.tar`.
+  `docker load -i url-shortener-oci.tar`. 7-day retention.
 
 The binary embeds a `git describe` version string of the form
 `<latest_tag>-<N>-g<sha>` (or just `<sha>` when no tags exist yet),


### PR DESCRIPTION
The binaries job was previously gated to PRs only, on the assumption that consumers of main would always pull the GHCR image instead. That assumption doesn't hold for users deploying the bare binary (systemd hosts, scratch VMs, dev environments without docker available), who today have no stable download path between tagged releases.

Drop the if-pull-request gate and split the artifact name by trigger:

  - PR:        binaries-pr-<number>      (7d retention, unchanged)
  - main push: binaries-main-<short_sha> (30d retention, new)

The short-sha mirrors the existing :main-<short_sha> Docker tag, so the binaries artifact and the image artifact for the same commit share an obvious naming relationship. 30 days is long enough for the artifact to stick around past the next release cadence; PRs stay at 7 days because their value is reviewer-scoped.

README updated to document the new artifact alongside :edge / :main-<short_sha>.