### PR TITLE
ci(release): align image tag, binary version, and git tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
     steps:
       # fetch-depth: 0 so `just build` -> `git describe` can resolve the
       # version string against the most recent tag, producing meaningful
-      # `1.2.3-N-gSHA` ldflags on PR/main builds instead of the bare SHA.
+      # `v1.2.3-N-gSHA` ldflags on PR/main builds instead of the bare SHA.
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # fetch-depth: 0 so the version baked into each binary reflects
-      # the distance from the most recent tag (e.g. `1.2.3-5-gabcdef0`).
+      # the distance from the most recent tag (e.g. `v1.2.3-5-gabcdef0`).
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -200,7 +200,7 @@ jobs:
       packages: write
     steps:
       # fetch-depth: 0 so the version build-arg picked up below reflects
-      # the distance from the most recent tag (e.g. `1.2.3-5-gabcdef0`),
+      # the distance from the most recent tag (e.g. `v1.2.3-5-gabcdef0`),
       # not just the bare commit SHA.
       - uses: actions/checkout@v6
         with:
@@ -209,7 +209,7 @@ jobs:
       - name: Resolve version from git
         id: version
         run: |
-          version=$(git describe --tags --always --dirty --match 'v[0-9]*' 2>/dev/null | sed -E 's/^v//' || echo "0.0.0-dev")
+          version=$(git describe --tags --always --dirty=-dev --match 'v[0-9]*' 2>/dev/null || echo "v0.0.0-dev")
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Resolved VERSION=$version"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,8 +4,11 @@
 # Produces, in parallel where it can:
 #
 #   1. A multi-arch (linux/amd64 + linux/arm64) container image published
-#      to GHCR under tags :MAJOR, :MAJOR.MINOR, :MAJOR.MINOR.PATCH and
-#      :latest (the latter only on stable, non-prerelease tags).
+#      to GHCR under :<git-tag> (e.g. :v1.2.3, :v1.2.3-beta1) and
+#      :latest (the latter only on stable, non-prerelease tags). The
+#      image tag matches the git tag verbatim, including the leading
+#      `v`, so a `git checkout v1.2.3` and `docker pull ...:v1.2.3`
+#      reference the same artifact by the same name.
 #
 #   2. Cross-compiled binary archives for linux/{amd64,arm64} and
 #      darwin/{amd64,arm64} plus a SHA256SUMS file, uploaded as GitHub
@@ -59,12 +62,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Strip the leading `v` from the tag so the binary's `version`
-      # subcommand reports semver-canonical "1.2.3" rather than "v1.2.3".
+      # Use the git tag verbatim (with leading `v`) as the version
+      # string so the binary's `version` subcommand, the docker image
+      # tag, and the GitHub tag all report the exact same identifier.
       # Done as a step so the value is reusable in build-args below.
       - name: Resolve version from tag
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
@@ -76,10 +80,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # docker/metadata-action turns `refs/tags/v1.2.3` into the
-      # canonical set of semver image tags (1.2.3, 1.2, 1, latest).
+      # Image tag set: the git tag verbatim plus :latest on stable
+      # releases. `type=ref,event=tag` echoes refs/tags/<X> as :<X>,
+      # so pushing v1.2.3 publishes :v1.2.3 (matching the git tag
+      # 1:1). We deliberately don't emit rolling :MAJOR / :MAJOR.MINOR
+      # tags -- they're noisy for a small project, and a stable
+      # "track the latest 1.x" pointer is exactly what :latest is for
+      # once a major is the current line.
+      #
       # `:latest` is moved only on stable (non-prerelease) tags, so
-      # pushing v1.2.3-beta1 publishes :1.2.3-beta1 without touching
+      # pushing v1.2.3-beta1 publishes :v1.2.3-beta1 without touching
       # the stable pointer. The dev counterpart (:edge) is moved by
       # the ci.yaml `image` job on every main push.
       - name: Derive image tags + labels
@@ -88,9 +98,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=ref,event=tag
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Build and push multi-arch image
@@ -135,10 +143,9 @@ jobs:
       - uses: extractions/setup-just@v4
 
       # The Justfile reads VERSION from `git describe --tags`, which on a
-      # tag push reports e.g. `1.2.3` (the leading `v` is stripped by the
-      # sed pipe in the Justfile). The release-binaries recipe emits
-      # url-shortener_${VERSION}_${os}_${arch}.tar.gz under ./dist along
-      # with SHA256SUMS.
+      # tag push reports e.g. `v1.2.3` verbatim. The release-binaries
+      # recipe emits url-shortener_${VERSION}_${os}_${arch}.tar.gz
+      # under ./dist along with SHA256SUMS.
       - name: Build release binaries
         run: just release-binaries
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ git tag -a v1.2.3 -m "v1.2.3"
 git push origin v1.2.3
 ```
 
-Use `just release-binaries 1.2.3` to produce the same archives locally
+Use `just release-binaries v1.2.3` to produce the same archives locally
 under `./dist/` (handy for smoke-testing before tagging).
 
 ## Code quality

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 # Build metadata injected via -ldflags.
-ARG VERSION=0.0.0-dev
+ARG VERSION=v0.0.0-dev
 ARG COMMIT=unknown
 ARG DATE=1970-01-01T00:00:00Z
 

--- a/Justfile
+++ b/Justfile
@@ -2,10 +2,17 @@
 # Run `just` (or `just help`) to list recipes.
 
 # Resolve the version string from git tags, matching the documented scheme:
-#   git describe --tags --always --dirty --match 'v[0-9]*'
-# Tags themselves start with `v`; the binary's version string strips that prefix
-# when the working tree is on an exact tag.
-VERSION                := `git describe --tags --always --dirty --match 'v[0-9]*' 2>/dev/null | sed -E 's/^v//' || echo "0.0.0-dev"`
+#   git describe --tags --always --dirty=-dev --match 'v[0-9]*'
+# The leading `v` is preserved so the binary's `version` subcommand prints
+# the same string as the git tag and the docker image tag (e.g. `v1.2.3`),
+# making it trivial to map a deployed binary back to the source revision.
+#
+# `--dirty=-dev` overrides the default `-dirty` mark with `-dev`, so a
+# local build off a tagged commit with uncommitted edits reports e.g.
+# `v1.2.3-dev` -- a clearer "this is a developer build" signal than the
+# bare git terminology, while CI runs (always clean checkouts) keep
+# emitting the unsuffixed string.
+VERSION                := `git describe --tags --always --dirty=-dev --match 'v[0-9]*' 2>/dev/null || echo "v0.0.0-dev"`
 COMMIT                 := `git rev-parse --short=12 HEAD 2>/dev/null || echo "unknown"`
 DATE                   := `date -u +%Y-%m-%dT%H:%M:%SZ`
 PLATFORMS              := "linux/amd64,linux/arm64"
@@ -202,7 +209,7 @@ docker-build:
 #
 # Usage:
 #   just release-binaries           # uses {{VERSION}}
-#   just release-binaries 1.2.3     # explicit version override
+#   just release-binaries v1.2.3    # explicit version override
 release-binaries V=VERSION: web-build
     #!/usr/bin/env bash
     set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -233,9 +233,10 @@ Pushing a `v*` semver tag triggers `.github/workflows/release.yaml` and
 publishes:
 
 - **Container images** to `ghcr.io/vancanhuit/url-shortener` for
-  linux/amd64 + linux/arm64. Tags: `:1.2.3`, `:1.2`, `:1`, plus
-  `:latest` on stable (non-prerelease) tags. Pre-releases like
-  `v1.2.3-beta1` publish only `:1.2.3-beta1` and don't move `:latest`.
+  linux/amd64 + linux/arm64. Image tags match the git tag verbatim:
+  pushing `v1.2.3` publishes `:v1.2.3`, and stable (non-prerelease)
+  tags also move `:latest`. Pre-releases like `v1.2.3-beta1`
+  publish only `:v1.2.3-beta1` and don't move `:latest`.
 - **Binary archives** `url-shortener_<version>_<os>_<arch>.tar.gz` for
   linux + darwin on both architectures, attached to the matching
   GitHub Release alongside `SHA256SUMS`.

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -7,7 +7,7 @@ package buildinfo
 //
 //nolint:gochecknoglobals // intentional: linker-injected metadata.
 var (
-	version = "0.0.0-dev"
+	version = "v0.0.0-dev"
 	commit  = "unknown"
 	date    = "1970-01-01T00:00:00Z"
 )


### PR DESCRIPTION
Make the docker image tag, the binary's reported version, and the git tag identical strings end-to-end. Three related changes:

1. Drop rolling :MAJOR / :MAJOR.MINOR image tags. At v0 they're actively misleading (`:0` floating across every minor bump within 0.x is the opposite of what users expect from a pre-1.0 project), and even at 1.x+ `:latest` already covers the "track the current line" use case once a major is current.

2. Switch the canonical version image tag from semver-canonical (:1.2.3) to the verbatim git ref (:v1.2.3). Replaces three `type=semver,pattern=...` rules in docker/metadata-action with a single `type=ref,event=tag`. `:latest` is unchanged -- stable tags still move it, prereleases still don't.

3. Stop stripping the leading `v` from the embedded binary version. The Justfile, ci.yaml's main-build version step, and release.yaml's tag-resolve step all now keep the `v` prefix, matching the git tag and the docker image tag character for character. The buildinfo.go default and the Dockerfile ARG default are bumped to v0.0.0-dev for the same reason.

Bonus: the `git describe` invocations now use `--dirty=-dev` instead of the default `-dirty` mark. A local build off a clean tag remains unsuffixed; a local build with uncommitted edits reports e.g. `v1.2.3-dev`, which reads more obviously as a developer build than the bare git terminology. CI runs always have clean checkouts so the change is a no-op there.

Filename of the binary archives now includes the `v` too: `url-shortener_v1.2.3_linux_amd64.tar.gz`. Slight churn for existing scripts, but cheap to update once and keeps the project's naming consistent.