### PR TITLE
ci(release): emit per-archive .sha256 files alongside SHA256SUMS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,7 +124,8 @@ jobs:
   binaries:
     name: binaries
     # Cross-compile the binary for linux/darwin x amd64/arm64 and upload
-    # the resulting tar.gz archives + SHA256SUMS as a workflow artifact:
+    # the resulting tar.gz archives, per-archive .tar.gz.sha256 files,
+    # and the aggregate SHA256SUMS as a workflow artifact:
     #
     #   - on PR:        binaries-pr-<number>      (7d retention)
     #   - on main push: binaries-main-<short_sha> (30d retention)
@@ -177,6 +178,7 @@ jobs:
           name: ${{ steps.artifact.outputs.name }}
           path: |
             dist/url-shortener_*.tar.gz
+            dist/url-shortener_*.tar.gz.sha256
             dist/SHA256SUMS
           if-no-files-found: error
           retention-days: ${{ steps.artifact.outputs.retention }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,8 +11,8 @@
 #      reference the same artifact by the same name.
 #
 #   2. Cross-compiled binary archives for linux/{amd64,arm64} and
-#      darwin/{amd64,arm64} plus a SHA256SUMS file, uploaded as GitHub
-#      Release assets.
+#      darwin/{amd64,arm64} plus per-archive `.sha256` files and an
+#      aggregate `SHA256SUMS`, all uploaded as GitHub Release assets.
 #
 #   3. A GitHub Release whose body is the auto-generated changelog
 #      between the previous tag and the new one, grouped by
@@ -145,7 +145,8 @@ jobs:
       # The Justfile reads VERSION from `git describe --tags`, which on a
       # tag push reports e.g. `v1.2.3` verbatim. The release-binaries
       # recipe emits url-shortener_${VERSION}_${os}_${arch}.tar.gz
-      # under ./dist along with SHA256SUMS.
+      # under ./dist, plus per-archive .tar.gz.sha256 files and an
+      # aggregate SHA256SUMS.
       - name: Build release binaries
         run: just release-binaries
 
@@ -173,4 +174,5 @@ jobs:
           prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
             dist/url-shortener_*.tar.gz
+            dist/url-shortener_*.tar.gz.sha256
             dist/SHA256SUMS

--- a/Justfile
+++ b/Justfile
@@ -200,9 +200,17 @@ docker-build:
 
 # Cross-compile the binary for linux/darwin x amd64/arm64 into ./dist,
 # packaging each as a tar.gz with the binary at the root and a
-# README.md alongside it. A SHA256SUMS file is emitted for the whole
-# set so consumers can verify downloads. The release workflow uploads
-# the tarballs + checksums as GitHub Release assets.
+# README.md alongside it. Two flavors of checksum are emitted:
+#
+#   - per-archive `<archive>.tar.gz.sha256` -- one line, verifiable
+#     in isolation with `sha256sum -c <file>.tar.gz.sha256`. Handy
+#     when a consumer downloads only one platform's archive.
+#   - aggregate `SHA256SUMS` -- one line per archive, verifiable as
+#     a set with `sha256sum -c SHA256SUMS`. Handy for mirroring or
+#     bulk-verifying everything in one shot.
+#
+# The release workflow uploads the tarballs + both checksum flavors
+# as GitHub Release assets.
 #
 # `web-build` runs once before the cross-compile loop so all four
 # binaries embed the same Tailwind / htmx assets.
@@ -236,6 +244,12 @@ release-binaries V=VERSION: web-build
                 -o "$stage/url-shortener" ./cmd/url-shortener
         cp README.md "$stage/"
         tar -C "$out" -czf "$out/${stem}.tar.gz" "$stem"
+        # Per-archive checksum sits next to the archive so a consumer
+        # who downloads just one platform can verify it without
+        # pulling SHA256SUMS too. Run from $out so the recorded path
+        # is the bare filename, matching how `sha256sum -c` resolves
+        # the target relative to the checksum file's directory.
+        (cd "$out" && sha256sum "${stem}.tar.gz" > "${stem}.tar.gz.sha256")
         rm -rf "$stage"
     done
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,10 @@ publishes:
   publish only `:v1.2.3-beta1` and don't move `:latest`.
 - **Binary archives** `url-shortener_<version>_<os>_<arch>.tar.gz` for
   linux + darwin on both architectures, attached to the matching
-  GitHub Release alongside `SHA256SUMS`.
+  GitHub Release alongside both per-archive `<archive>.tar.gz.sha256`
+  files and an aggregate `SHA256SUMS`. Verify a single archive with
+  `sha256sum -c <archive>.tar.gz.sha256`, or all of them at once with
+  `sha256sum -c SHA256SUMS`.
 
 See `CONTRIBUTING.md` for the tag-and-push flow that produces them.
 
@@ -257,7 +260,8 @@ Each push to `main` also uploads a binaries artifact to the workflow
 run for users who deploy the binary directly rather than the image:
 
 - `binaries-main-<short_sha>` -- `url-shortener_<version>_<os>_<arch>.tar.gz`
-  for `linux`/`darwin` x `amd64`/`arm64`, plus `SHA256SUMS`. 30-day
+  for `linux`/`darwin` x `amd64`/`arm64`, plus per-archive
+  `.tar.gz.sha256` files and an aggregate `SHA256SUMS`. 30-day
   retention, indexed by the same short-sha as the matching `:main-<short_sha>`
   image so the two stay in lockstep.
 
@@ -265,7 +269,8 @@ Pull-request runs do **not** push to GHCR. Instead they upload two
 artifacts to the workflow run that you can grab from the Actions UI:
 
 - `binaries-pr-<N>` -- `url-shortener_<version>_<os>_<arch>.tar.gz`
-  for all four platforms, plus `SHA256SUMS`. 7-day retention.
+  for all four platforms, plus per-archive `.tar.gz.sha256` files
+  and an aggregate `SHA256SUMS`. 7-day retention.
 - `oci-image-pr-<N>` -- a single multi-arch OCI tarball; load it with
   `docker load -i url-shortener-oci.tar`. 7-day retention.
 


### PR DESCRIPTION
Add a per-archive checksum file next to each .tar.gz in dist/, in addition to the existing aggregate SHA256SUMS. Two complementary verification flows are now supported:

  - Per archive: `sha256sum -c <archive>.tar.gz.sha256` Useful when a consumer downloads only one platform's tarball (most users only need linux/amd64) and doesn't want to pull the aggregate SHA256SUMS just to verify it.

  - All archives: `sha256sum -c SHA256SUMS` Useful for mirroring or bulk-verifying the entire release set in one command.

The per-archive files are named `<archive>.tar.gz.sha256` and contain a single `sha256sum`-format line:

  <hash>  <archive>.tar.gz

The recorded path is the bare filename (not a directory-prefixed path) because the file is generated from inside dist/, which is how `sha256sum -c` resolves the target relative to the checksum file's own directory. Verified end-to-end locally with `sha256sum -c` on the linux/amd64 output.

Updates:
  - Justfile release-binaries recipe emits `<stem>.tar.gz.sha256` inside the per-platform loop, right after the tar.gz is sealed.
  - release.yaml softprops/action-gh-release `files:` glob picks up the new `*.tar.gz.sha256` pattern so they ride along with the archives as Release assets.
  - ci.yaml binaries-artifact path glob does the same for the PR and main-push workflow artifacts, so dev consumers get the same verification surface as release consumers.
  - README and recipe doc-comments document both flavors and the one-liner verification commands.