### PR TITLE
ci: extract toolchain setup and build metadata into composite actions

### DIFF
--- a/.github/actions/resolve-build-metadata/action.yaml
+++ b/.github/actions/resolve-build-metadata/action.yaml
@@ -1,0 +1,53 @@
+name: Resolve build metadata
+description: >-
+  Resolve the version string and build date injected into the binary via
+  ldflags and forwarded to the Docker image as build-args. Both image jobs
+  (ci.yaml on main/PR, release.yaml on tag pushes) need the same values
+  derived the same way; this action is the single source of truth.
+
+inputs:
+  version-source:
+    description: >-
+      Where the version string comes from:
+        - "describe": run `git describe --tags --always --dirty=-dev
+          --match 'v[0-9]*'`, falling back to `v0.0.0-dev`. Used on PR and
+          main-branch builds where there's no exact tag.
+        - "tag": use $GITHUB_REF_NAME verbatim (with leading `v`). Used on
+          tag-push releases so the binary, image tag, and git tag all
+          report the same identifier.
+    required: false
+    default: describe
+
+outputs:
+  version:
+    description: Resolved version string (e.g. v1.2.3 or v1.2.3-5-gabcdef0-dev).
+    value: ${{ steps.resolve.outputs.version }}
+  date:
+    description: >-
+      Build date as RFC3339 UTC, taken from the committer timestamp of HEAD.
+      Reproducible across re-runs of the same SHA, human-readable on the
+      `version` subcommand.
+    value: ${{ steps.resolve.outputs.date }}
+
+runs:
+  using: composite
+  steps:
+    - id: resolve
+      shell: bash
+      run: |
+        case "${{ inputs.version-source }}" in
+          tag)
+            version="${GITHUB_REF_NAME}"
+            ;;
+          describe)
+            version=$(git describe --tags --always --dirty=-dev --match 'v[0-9]*' 2>/dev/null || echo "v0.0.0-dev")
+            ;;
+          *)
+            echo "unknown version-source: ${{ inputs.version-source }}" >&2
+            exit 1
+            ;;
+        esac
+        date=$(TZ=UTC git show -s --format='%cd' --date='format-local:%Y-%m-%dT%H:%M:%SZ' HEAD)
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+        echo "date=$date" >> "$GITHUB_OUTPUT"
+        echo "Resolved VERSION=$version DATE=$date"

--- a/.github/actions/setup-toolchain/action.yaml
+++ b/.github/actions/setup-toolchain/action.yaml
@@ -1,0 +1,41 @@
+name: Set up toolchain
+description: >-
+  Install the Go, Node, and just toolchains used by every build/test/release
+  job. Centralizes the action versions, cache config, and Node-24 opt-in so
+  workflow jobs can stay focused on what they actually run.
+
+inputs:
+  go-version:
+    description: Go toolchain version to install (e.g. 1.26.2).
+    required: true
+  node-version:
+    description: Node.js version to install (e.g. 24.14.1).
+    required: true
+  go-cache:
+    description: >-
+      Whether actions/setup-go should manage the build/module cache.
+      Set to "false" for short-lived jobs that don't benefit from it.
+    required: false
+    default: "true"
+  node-cache-dependency-path:
+    description: >-
+      Lockfile path forwarded to actions/setup-node's `cache-dependency-path`.
+      Defaults to the Tailwind/htmx toolchain that `just web-build` consumes.
+    required: false
+    default: web/tailwind/package-lock.json
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-go@v6
+      with:
+        go-version: ${{ inputs.go-version }}
+        cache: ${{ inputs.go-cache }}
+
+    - uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: npm
+        cache-dependency-path: ${{ inputs.node-cache-dependency-path }}
+
+    - uses: extractions/setup-just@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,11 +42,16 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      # commitlint runs `just init`, which `npm ci`s the root toolchain
+      # (husky + @commitlint/*). Point the npm cache at the root lockfile
+      # rather than the Tailwind one, and skip the Go module cache since
+      # this job never invokes the Go toolchain.
+      - uses: ./.github/actions/setup-toolchain
         with:
+          go-version: ${{ env.GO_VERSION }}
           node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-      - uses: extractions/setup-just@v4
+          go-cache: "false"
+          node-cache-dependency-path: package-lock.json
       - run: just init
       # The PR title becomes the squash-merge commit message on `main`, so
       # that's the message that has to be conventional. Per-commit hygiene
@@ -66,19 +71,14 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v6
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
       # `just build` depends on `web-build`, which `npm ci`s the Tailwind +
       # htmx toolchain in web/tailwind/ and emits the .gitignore'd assets
-      # the Go binary embeds. Cache is keyed on the tailwind lockfile.
-      - uses: actions/setup-node@v6
+      # the Go binary embeds. The composite caches Go modules and npm,
+      # keyed on web/tailwind/package-lock.json by default.
+      - uses: ./.github/actions/setup-toolchain
         with:
+          go-version: ${{ env.GO_VERSION }}
           node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-          cache-dependency-path: web/tailwind/package-lock.json
-      - uses: extractions/setup-just@v4
       - name: just build
         run: just build
       - name: just test
@@ -97,18 +97,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v6
+      # Same toolchain setup as the `go` job: `just test-integration`
+      # depends on `build`, which depends on `web-build` (npm ci).
+      - uses: ./.github/actions/setup-toolchain
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache: true
-      # Same setup-node story as the `go` job: `just test-integration`
-      # depends on `build`, which depends on `web-build` (npm ci).
-      - uses: actions/setup-node@v6
-        with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-          cache-dependency-path: web/tailwind/package-lock.json
-      - uses: extractions/setup-just@v4
       # `just test-integration` brings up the `test`-profile infra
       # (db-test on 5433 + redis-test on 6380), builds the binary, applies
       # migrations against the test DB, and runs the build-tagged tests --
@@ -143,16 +137,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v6
+      - uses: ./.github/actions/setup-toolchain
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache: true
-      - uses: actions/setup-node@v6
-        with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-          cache-dependency-path: web/tailwind/package-lock.json
-      - uses: extractions/setup-just@v4
 
       - name: just release-binaries
         run: just release-binaries
@@ -208,12 +196,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Resolve version from git
-        id: version
-        run: |
-          version=$(git describe --tags --always --dirty=-dev --match 'v[0-9]*' 2>/dev/null || echo "v0.0.0-dev")
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "Resolved VERSION=$version"
+      # Resolve VERSION (via `git describe`) + DATE (committer timestamp,
+      # RFC3339 UTC). Same composite is used by release.yaml with
+      # `version-source: tag` so binary, image tag, and git tag all line
+      # up on tag pushes.
+      - name: Resolve build metadata
+        id: meta-build
+        uses: ./.github/actions/resolve-build-metadata
 
       - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
@@ -256,9 +245,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VERSION=${{ steps.version.outputs.version }}
+            VERSION=${{ steps.meta-build.outputs.version }}
             COMMIT=${{ github.sha }}
-            DATE=${{ github.event.head_commit.timestamp }}
+            DATE=${{ steps.meta-build.outputs.date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -276,9 +265,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VERSION=${{ steps.version.outputs.version }}
+            VERSION=${{ steps.meta-build.outputs.version }}
             COMMIT=${{ github.sha }}
-            DATE=${{ github.event.pull_request.updated_at }}
+            DATE=${{ steps.meta-build.outputs.date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,13 +62,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Use the git tag verbatim (with leading `v`) as the version
-      # string so the binary's `version` subcommand, the docker image
-      # tag, and the GitHub tag all report the exact same identifier.
-      # Done as a step so the value is reusable in build-args below.
-      - name: Resolve version from tag
-        id: version
-        run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+      # Resolve VERSION (git tag verbatim, including leading `v`) and
+      # DATE (committer timestamp of HEAD, RFC3339 UTC) via the shared
+      # composite. ci.yaml uses the same composite with the default
+      # `version-source: describe` so the binary's `version` subcommand,
+      # the Docker image tag, and the git tag all report the same
+      # identifier on tag pushes.
+      - name: Resolve build metadata
+        id: meta-build
+        uses: ./.github/actions/resolve-build-metadata
+        with:
+          version-source: tag
 
       - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
@@ -110,9 +114,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VERSION=${{ steps.version.outputs.version }}
+            VERSION=${{ steps.meta-build.outputs.version }}
             COMMIT=${{ github.sha }}
-            DATE=${{ github.event.repository.pushed_at }}
+            DATE=${{ steps.meta-build.outputs.date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -127,20 +131,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
+      # `just release-binaries` depends on `just web-build`, which runs
+      # `npm ci` in web/tailwind/. Same composite as ci.yaml.
+      - uses: ./.github/actions/setup-toolchain
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache: true
-
-      # `just release-binaries` depends on `just web-build`, which runs
-      # `npm ci` in web/tailwind/. Same setup pattern as the ci workflow.
-      - uses: actions/setup-node@v6
-        with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-          cache-dependency-path: web/tailwind/package-lock.json
-
-      - uses: extractions/setup-just@v4
 
       # The Justfile reads VERSION from `git describe --tags`, which on a
       # tag push reports e.g. `v1.2.3` verbatim. The release-binaries


### PR DESCRIPTION
Two new composites under .github/actions/ deduplicate the workflow YAML:

- setup-toolchain: installs Go + Node + just with the action versions, cache config, and Node-24 opt-in pinned in one place. Inputs let commitlint disable the Go cache and point npm at the root lockfile while every other job uses the Tailwind one.
- resolve-build-metadata: emits version/date outputs. version-source toggles between `git describe --dirty=-dev` (PR/main) and the raw $GITHUB_REF_NAME (tag pushes); date is always the committer timestamp of HEAD in RFC3339 UTC.

ci.yaml and release.yaml now reference the composites instead of inlining setup-go/setup-node/setup-just and the version/date shell blocks. Net effect is the same images, binaries, and ldflags, with ~70 fewer lines of YAML and a single place to bump action versions or tweak the version-string scheme.