### PR TITLE
build(docker): add HEALTHCHECK invoking the binary's healthcheck subcommand

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,4 +85,13 @@ EXPOSE 8080
 
 USER nonroot:nonroot
 
+# Probe the binary's own /healthz via the `healthcheck` subcommand.
+# Distroless ships neither curl nor wget, so the binary itself is the
+# probe. Mirrors the compose.yaml healthcheck so `docker run` users get
+# the same liveness signal without composing a stack. Kubernetes and
+# other orchestrators that drive their own probes can override this
+# with their own livenessProbe.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD ["/usr/local/bin/url-shortener", "healthcheck"]
+
 ENTRYPOINT ["/usr/local/bin/url-shortener"]


### PR DESCRIPTION
Bake the same probe compose.yaml uses into the image itself so `docker run` users get a liveness signal without composing a stack. Distroless ships neither curl nor wget, so the binary's own `healthcheck` subcommand (which probes /healthz over loopback) is the only viable probe in the runtime layer.

Tunables (interval=30s, timeout=3s, start-period=5s, retries=3) are conservative defaults aimed at standalone Docker hosts. compose.yaml keeps its tighter 5s interval so `docker compose up --wait` returns promptly; Kubernetes and other orchestrators that drive their own livenessProbe will override this entirely.