### PR TITLE
build(docker): bake static OCI image labels into the runtime stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,18 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # -----------------------------------------------------------------------------
 FROM gcr.io/distroless/static-debian13:nonroot AS runtime
 
+# Static OCI image labels. Dynamic ones (version, revision, created)
+# are emitted per build by docker/metadata-action in CI; baking the
+# fixed identity here means `docker build` outside CI inherits them
+# too. See https://github.com/opencontainers/image-spec/blob/main/annotations.md
+LABEL org.opencontainers.image.title="url-shortener" \
+      org.opencontainers.image.description="A small URL-shortener service with a JSON API and HTMX web UI." \
+      org.opencontainers.image.source="https://github.com/vancanhuit/url-shortener" \
+      org.opencontainers.image.url="https://github.com/vancanhuit/url-shortener" \
+      org.opencontainers.image.documentation="https://github.com/vancanhuit/url-shortener#readme" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.vendor="vancanhuit"
+
 WORKDIR /app
 
 COPY --from=builder /out/url-shortener /usr/local/bin/url-shortener

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 vancanhuit
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Add LABEL org.opencontainers.image.{title,description,source,url, documentation,licenses,vendor} to the runtime stage so `docker build` outside CI inherits the fixed identity metadata. Dynamic labels (version, revision, created) keep being emitted per build by docker/metadata-action in ci.yaml and release.yaml; baking those would shadow the per-build values.

Also add a top-level LICENSE (MIT) so the licenses label is self-consistent and tools like go-licenses / pip-style scanners have a file to point at.