### PR TITLE
fix(server): forward request context to slog request logger

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -168,7 +168,7 @@ func slogRequestLogger(logger *slog.Logger) echo.MiddlewareFunc {
 		LogLatency:   true,
 		LogRequestID: true,
 		HandleError:  true,
-		LogValuesFunc: func(_ *echo.Context, v middleware.RequestLoggerValues) error {
+		LogValuesFunc: func(c *echo.Context, v middleware.RequestLoggerValues) error {
 			level := slog.LevelInfo
 			switch {
 			case v.Error != nil, v.Status >= 500:
@@ -187,7 +187,16 @@ func slogRequestLogger(logger *slog.Logger) echo.MiddlewareFunc {
 			if v.Error != nil {
 				attrs = append(attrs, "error", v.Error.Error())
 			}
-			logger.Log(context.Background(), level, "http request", attrs...)
+			// Forward the request context so handlers like otelslog can
+			// extract the trace/span IDs the http server installed.
+			// Falls back to Background only if the request is somehow
+			// detached (e.g. tests that synthesise a logger value
+			// directly), which keeps the call total-safe.
+			ctx := context.Background()
+			if c != nil && c.Request() != nil {
+				ctx = c.Request().Context()
+			}
+			logger.Log(ctx, level, "http request", attrs...)
 			return nil
 		},
 	})


### PR DESCRIPTION
Propagate the *echo.Context from the request-logger middleware into slog.Log, so future context-aware handlers (otelslog, sloggcp, slogcontext) can extract the trace/span IDs and request-scoped attributes the HTTP stack installed. Previously every access-log line was emitted with context.Background(), which silently dropped that metadata even though the request_id was already encoded as a log attribute.

Falls back to Background when the echo.Context or its inner *http.Request is nil so a synthesised LogValues value (e.g. in tests that exercise the closure directly) can still log without panicking.