### PR TITLE
ci: drop setup-qemu-action from image jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -204,7 +204,12 @@ jobs:
         id: meta-build
         uses: ./.github/actions/resolve-build-metadata
 
-      - uses: docker/setup-qemu-action@v4
+      # No setup-qemu-action: every Dockerfile stage that runs commands
+      # is pinned to --platform=$BUILDPLATFORM, and the Go builder
+      # cross-compiles via GOOS/GOARCH instead of emulating the target.
+      # The runtime stage is distroless with no RUN steps, so buildx
+      # never has to execute target-arch instructions. Add QEMU back
+      # if a future change introduces a RUN in a non-BUILDPLATFORM stage.
       - uses: docker/setup-buildx-action@v4
 
       # GHCR login only on main pushes. PRs (incl. forks) skip this and

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,7 +74,10 @@ jobs:
         with:
           version-source: tag
 
-      - uses: docker/setup-qemu-action@v4
+      # No setup-qemu-action: see ci.yaml's image job for the rationale.
+      # Every Dockerfile stage that runs commands is pinned to
+      # --platform=$BUILDPLATFORM and the Go builder cross-compiles via
+      # GOOS/GOARCH, so buildx never has to emulate target-arch code.
       - uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR


### PR DESCRIPTION
No Dockerfile stage executes target-arch code during build:

- web-builder and builder stages are pinned to --platform=$BUILDPLATFORM
- the Go builder cross-compiles via GOOS=$TARGETOS GOARCH=$TARGETARCH
- the runtime stage (distroless static) has no RUN directives, only COPY/LABEL/EXPOSE/USER/HEALTHCHECK/ENTRYPOINT

So buildx never needs binfmt_misc emulation. Removing the action shaves a few seconds off every image build and removes a dependency that was silently registering handlers nothing used. A comment near setup-buildx-action in both workflows documents when QEMU would need to come back (e.g. adding a RUN in a non-BUILDPLATFORM stage).