### PR TITLE
ci: surface OCI metadata on the multi-arch manifest index

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -233,8 +233,28 @@ jobs:
       - name: Derive image tags + labels
         id: meta
         uses: docker/metadata-action@v6
+        env:
+          # Write annotations onto both the multi-arch manifest index
+          # AND each per-platform manifest. GHCR's package UI reads the
+          # description (and other OCI fields) from the index for
+          # multi-arch images, so leaving annotations at the default
+          # ("manifest" only) leaves the registry page blank even though
+          # the per-platform configs carry the same labels via
+          # Dockerfile LABEL.
+          # Docs: https://github.com/docker/metadata-action#annotations
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: index,manifest
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}
+          # Static OCI fields are also baked into the Dockerfile so
+          # `docker build` outside CI inherits them; restating them
+          # here is what populates the `annotations` output that the
+          # build-push-action step consumes.
+          labels: |
+            org.opencontainers.image.title=url-shortener
+            org.opencontainers.image.description=A small URL-shortener service with a JSON API and HTMX web UI.
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.vendor=vancanhuit
+            org.opencontainers.image.documentation=https://github.com/${{ github.repository }}#readme
           tags: |
             type=ref,event=pr
             type=raw,value=edge,enable={{is_default_branch}}
@@ -249,6 +269,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Annotations cover the manifest index for GHCR's UI; labels
+          # cover the per-platform image configs for `docker inspect`.
+          annotations: ${{ steps.meta.outputs.annotations }}
           build-args: |
             VERSION=${{ steps.meta-build.outputs.version }}
             COMMIT=${{ github.sha }}
@@ -269,6 +292,7 @@ jobs:
           outputs: type=oci,dest=./url-shortener-oci.tar
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           build-args: |
             VERSION=${{ steps.meta-build.outputs.version }}
             COMMIT=${{ github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,8 +102,23 @@ jobs:
       - name: Derive image tags + labels
         id: meta
         uses: docker/metadata-action@v6
+        env:
+          # Annotate both the manifest index and per-platform manifests
+          # so GHCR's package UI surfaces description/source/etc. for
+          # the multi-arch image. See ci.yaml's image job for the full
+          # rationale.
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: index,manifest
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Static OCI fields are also baked into the Dockerfile; this
+          # block exists so docker/metadata-action emits them as part
+          # of the `annotations` output consumed below.
+          labels: |
+            org.opencontainers.image.title=url-shortener
+            org.opencontainers.image.description=A small URL-shortener service with a JSON API and HTMX web UI.
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.vendor=vancanhuit
+            org.opencontainers.image.documentation=https://github.com/${{ github.repository }}#readme
           tags: |
             type=ref,event=tag
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
@@ -116,6 +131,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Annotations populate the manifest index that GHCR's UI
+          # reads; labels populate the per-platform image configs.
+          annotations: ${{ steps.meta.outputs.annotations }}
           build-args: |
             VERSION=${{ steps.meta-build.outputs.version }}
             COMMIT=${{ github.sha }}


### PR DESCRIPTION
GHCR's package UI reads description, source, licenses, etc. from manifest-index annotations for multi-arch images. The Dockerfile LABELs land on per-platform image configs only, so the registry page rendered "No description provided" even though every pulled image carried the metadata.

Two-part fix in both ci.yaml and release.yaml image jobs:

  1. docker/metadata-action: declare the static OCI fields via the `labels` input and set DOCKER_METADATA_ANNOTATIONS_LEVELS to `index,manifest` so they propagate to the action's `annotations` output (default is `manifest` only, which is what was leaving the index bare).
  2. docker/build-push-action: pass `annotations: ${{ steps.meta.outputs.annotations }}` so buildx writes them onto the manifest list, alongside the per-platform image labels.

The Dockerfile LABEL block stays as the source of truth for builds done outside CI (`docker build` on a developer laptop).