### PR TITLE
build(docker): drop unused 'runtime' stage alias

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # -----------------------------------------------------------------------------
 # Runtime stage: distroless static, nonroot.
 # -----------------------------------------------------------------------------
-FROM gcr.io/distroless/static-debian13:nonroot AS runtime
+FROM gcr.io/distroless/static-debian13:nonroot
 
 # Static OCI image labels. Dynamic ones (version, revision, created)
 # are emitted per build by docker/metadata-action in CI; baking the


### PR DESCRIPTION
The final stage was named `AS runtime` but no `COPY --from=runtime` ever referenced it -- the alias only matters when a downstream stage needs to copy artifacts back. The section comment above the FROM already calls out that this is the runtime stage, so the alias was purely decorative.

No behaviour change: buildx still treats the last stage as the default build target.