### PR TITLE
feat(store): expose pgx connection pool tunables via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ local `compose.yaml` overrides them for development.
 | `URL_SHORTENER_REDIS_URL`      | _(empty)_                     | **Required.** Redis connection string. Redacted when printed.   |
 | `URL_SHORTENER_AUTO_MIGRATE`   | `false`                       | When `true`, `run` applies migrations before serving. Convenient for local dev / single-replica CI; production deployments should leave this off and run `migrate up` as a separate step. |
 | `URL_SHORTENER_CODE_LENGTH`    | `7`                           | Length of auto-generated short codes (base62). Must be in [4, 64]. |
+| `URL_SHORTENER_DB_MAX_CONNS`           | _(pgx default: max(4, NumCPU))_ | Upper bound on simultaneous Postgres connections. Set above the default to absorb burst load without queueing requests on the pool. |
+| `URL_SHORTENER_DB_MIN_CONNS`           | _(pgx default: 0)_              | Idle connections kept warm. Useful to amortize TLS/handshake cost on bursty workloads. |
+| `URL_SHORTENER_DB_MAX_CONN_LIFETIME`   | _(pgx default: 1h)_             | Hard cap on a connection's age. Forces rotation through floating-IP failovers and clears DB-side connection-state drift. Accepts Go duration syntax (e.g. `30m`, `2h`). |
+| `URL_SHORTENER_DB_MAX_CONN_IDLE_TIME`  | _(pgx default: 30m)_            | How long a connection may sit unused before being closed. |
+| `URL_SHORTENER_DB_HEALTH_CHECK_PERIOD` | _(pgx default: 1m)_             | How often pgx scans the pool for stale connections. |
+
+Pool tunables are zero by default, in which case pgx's own defaults apply.
+Production deployments behind a fronting proxy (PgBouncer, RDS Proxy)
+typically want `DB_MAX_CONNS` raised to match the pool's per-replica
+backend cap and `DB_MAX_CONN_LIFETIME` lowered to a few minutes.
 
 Run `url-shortener config` to print the fully resolved configuration with
 passwords replaced by `REDACTED`.

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -43,7 +43,13 @@ func newRunCmd() *cobra.Command {
 						return err
 					}
 				}
-				st, err = store.New(cmd.Context(), cfg.DatabaseURL)
+				st, err = store.NewWithPool(cmd.Context(), cfg.DatabaseURL, store.PoolConfig{
+					MaxConns:          cfg.DBMaxConns,
+					MinConns:          cfg.DBMinConns,
+					MaxConnLifetime:   cfg.DBMaxConnLifetime,
+					MaxConnIdleTime:   cfg.DBMaxConnIdleTime,
+					HealthCheckPeriod: cfg.DBHealthCheckPeriod,
+				})
 				if err != nil {
 					return err
 				}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/spf13/viper"
 )
@@ -58,6 +59,17 @@ type Config struct {
 	// CodeLength is the length of auto-generated short codes. Validated by
 	// the shortener package: must be in [shortener.MinLength, MaxLength].
 	CodeLength int `mapstructure:"code_length" json:"code_length"`
+
+	// Postgres connection-pool tunables. All zero by default, in which
+	// case pgx's own defaults apply. See store.PoolConfig for the
+	// per-knob semantics. Production deployments typically want at
+	// least DBMaxConns set above pgx's default of max(4, NumCPU) to
+	// absorb burst load without queueing requests on the pool.
+	DBMaxConns          int32         `mapstructure:"db_max_conns"           json:"db_max_conns"`
+	DBMinConns          int32         `mapstructure:"db_min_conns"           json:"db_min_conns"`
+	DBMaxConnLifetime   time.Duration `mapstructure:"db_max_conn_lifetime"   json:"db_max_conn_lifetime"`
+	DBMaxConnIdleTime   time.Duration `mapstructure:"db_max_conn_idle_time"  json:"db_max_conn_idle_time"`
+	DBHealthCheckPeriod time.Duration `mapstructure:"db_health_check_period" json:"db_health_check_period"`
 }
 
 // Load reads the configuration from environment variables and applies the
@@ -74,6 +86,9 @@ func Load() (Config, error) {
 	for _, key := range []string{
 		"env", "addr", "base_url", "log_level", "log_format",
 		"database_url", "redis_url", "auto_migrate", "code_length",
+		"db_max_conns", "db_min_conns",
+		"db_max_conn_lifetime", "db_max_conn_idle_time",
+		"db_health_check_period",
 	} {
 		_ = v.BindEnv(key)
 	}
@@ -138,6 +153,29 @@ func (c Config) Validate() error {
 	// to start instead of silently degrading.
 	if c.RedisURL == "" {
 		return fmt.Errorf("config: redis_url must not be empty")
+	}
+
+	// Pool tunables: any explicit value must be non-negative; when both
+	// MinConns and MaxConns are set, MinConns must not exceed MaxConns.
+	// Zero is the "leave pgx default" sentinel and is always allowed.
+	if c.DBMaxConns < 0 {
+		return fmt.Errorf("config: db_max_conns must be >= 0")
+	}
+	if c.DBMinConns < 0 {
+		return fmt.Errorf("config: db_min_conns must be >= 0")
+	}
+	if c.DBMaxConns > 0 && c.DBMinConns > c.DBMaxConns {
+		return fmt.Errorf("config: db_min_conns (%d) must not exceed db_max_conns (%d)",
+			c.DBMinConns, c.DBMaxConns)
+	}
+	if c.DBMaxConnLifetime < 0 {
+		return fmt.Errorf("config: db_max_conn_lifetime must be >= 0")
+	}
+	if c.DBMaxConnIdleTime < 0 {
+		return fmt.Errorf("config: db_max_conn_idle_time must be >= 0")
+	}
+	if c.DBHealthCheckPeriod < 0 {
+		return fmt.Errorf("config: db_health_check_period must be >= 0")
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/vancanhuit/url-shortener/internal/config"
 )
@@ -79,6 +80,71 @@ func TestLoad_EnvOverrides(t *testing.T) {
 	}
 	if cfg != want {
 		t.Errorf("cfg = %+v\nwant %+v", cfg, want)
+	}
+}
+
+func TestLoad_DBPoolEnvOverrides(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("URL_SHORTENER_REDIS_URL", "redis://localhost:6379/0")
+	t.Setenv("URL_SHORTENER_DB_MAX_CONNS", "32")
+	t.Setenv("URL_SHORTENER_DB_MIN_CONNS", "4")
+	t.Setenv("URL_SHORTENER_DB_MAX_CONN_LIFETIME", "30m")
+	t.Setenv("URL_SHORTENER_DB_MAX_CONN_IDLE_TIME", "5m")
+	t.Setenv("URL_SHORTENER_DB_HEALTH_CHECK_PERIOD", "15s")
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load(): %v", err)
+	}
+
+	if cfg.DBMaxConns != 32 {
+		t.Errorf("DBMaxConns = %d, want 32", cfg.DBMaxConns)
+	}
+	if cfg.DBMinConns != 4 {
+		t.Errorf("DBMinConns = %d, want 4", cfg.DBMinConns)
+	}
+	if cfg.DBMaxConnLifetime != 30*time.Minute {
+		t.Errorf("DBMaxConnLifetime = %v, want 30m", cfg.DBMaxConnLifetime)
+	}
+	if cfg.DBMaxConnIdleTime != 5*time.Minute {
+		t.Errorf("DBMaxConnIdleTime = %v, want 5m", cfg.DBMaxConnIdleTime)
+	}
+	if cfg.DBHealthCheckPeriod != 15*time.Second {
+		t.Errorf("DBHealthCheckPeriod = %v, want 15s", cfg.DBHealthCheckPeriod)
+	}
+}
+
+func TestValidate_RejectsBadDBPoolValues(t *testing.T) {
+	t.Parallel()
+
+	const redisOK = "redis://localhost:6379/0"
+	base := func() config.Config {
+		return config.Config{
+			Env: "prod", Addr: ":8080", BaseURL: "x",
+			LogLevel: "info", LogFormat: "json", RedisURL: redisOK,
+		}
+	}
+
+	cases := map[string]func(*config.Config){
+		"negative max": func(c *config.Config) { c.DBMaxConns = -1 },
+		"negative min": func(c *config.Config) { c.DBMinConns = -1 },
+		"min greater": func(c *config.Config) {
+			c.DBMaxConns = 5
+			c.DBMinConns = 10
+		},
+		"negative lifetime":  func(c *config.Config) { c.DBMaxConnLifetime = -time.Second },
+		"negative idle":      func(c *config.Config) { c.DBMaxConnIdleTime = -time.Second },
+		"negative healthchk": func(c *config.Config) { c.DBHealthCheckPeriod = -time.Second },
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			c := base()
+			mutate(&c)
+			if err := c.Validate(); err == nil {
+				t.Errorf("Validate() returned nil; want error")
+			}
+		})
 	}
 }
 

--- a/internal/store/pool_test.go
+++ b/internal/store/pool_test.go
@@ -1,0 +1,103 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Test the merge logic in isolation. This is an internal_test (same
+// package) because applyPoolConfig is unexported -- the function is a
+// pure transformation on *pgxpool.Config and the alternative
+// (exporting it) would widen the API for no consumer benefit.
+func TestApplyPoolConfig(t *testing.T) {
+	t.Parallel()
+
+	// A real pgxpool.ParseConfig is the only way to mint a *Config
+	// with the pgx defaults populated; constructing one with `&Config{}`
+	// would zero out fields we explicitly want to preserve.
+	baseURL := "postgres://user:pass@localhost:5432/db?sslmode=disable"
+
+	t.Run("zero PoolConfig leaves pgx defaults intact", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := pgxpool.ParseConfig(baseURL)
+		if err != nil {
+			t.Fatalf("ParseConfig: %v", err)
+		}
+		before := *cfg
+
+		applyPoolConfig(cfg, PoolConfig{})
+
+		if cfg.MaxConns != before.MaxConns {
+			t.Errorf("MaxConns mutated: got %d, want %d", cfg.MaxConns, before.MaxConns)
+		}
+		if cfg.MinConns != before.MinConns {
+			t.Errorf("MinConns mutated: got %d, want %d", cfg.MinConns, before.MinConns)
+		}
+		if cfg.MaxConnLifetime != before.MaxConnLifetime {
+			t.Errorf("MaxConnLifetime mutated: got %v, want %v", cfg.MaxConnLifetime, before.MaxConnLifetime)
+		}
+		if cfg.MaxConnIdleTime != before.MaxConnIdleTime {
+			t.Errorf("MaxConnIdleTime mutated: got %v, want %v", cfg.MaxConnIdleTime, before.MaxConnIdleTime)
+		}
+		if cfg.HealthCheckPeriod != before.HealthCheckPeriod {
+			t.Errorf("HealthCheckPeriod mutated: got %v, want %v", cfg.HealthCheckPeriod, before.HealthCheckPeriod)
+		}
+	})
+
+	t.Run("non-zero fields override defaults", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := pgxpool.ParseConfig(baseURL)
+		if err != nil {
+			t.Fatalf("ParseConfig: %v", err)
+		}
+
+		pc := PoolConfig{
+			MaxConns:          25,
+			MinConns:          5,
+			MaxConnLifetime:   30 * time.Minute,
+			MaxConnIdleTime:   5 * time.Minute,
+			HealthCheckPeriod: 15 * time.Second,
+		}
+		applyPoolConfig(cfg, pc)
+
+		if cfg.MaxConns != pc.MaxConns {
+			t.Errorf("MaxConns = %d, want %d", cfg.MaxConns, pc.MaxConns)
+		}
+		if cfg.MinConns != pc.MinConns {
+			t.Errorf("MinConns = %d, want %d", cfg.MinConns, pc.MinConns)
+		}
+		if cfg.MaxConnLifetime != pc.MaxConnLifetime {
+			t.Errorf("MaxConnLifetime = %v, want %v", cfg.MaxConnLifetime, pc.MaxConnLifetime)
+		}
+		if cfg.MaxConnIdleTime != pc.MaxConnIdleTime {
+			t.Errorf("MaxConnIdleTime = %v, want %v", cfg.MaxConnIdleTime, pc.MaxConnIdleTime)
+		}
+		if cfg.HealthCheckPeriod != pc.HealthCheckPeriod {
+			t.Errorf("HealthCheckPeriod = %v, want %v", cfg.HealthCheckPeriod, pc.HealthCheckPeriod)
+		}
+	})
+
+	t.Run("partial override leaves untouched fields alone", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := pgxpool.ParseConfig(baseURL)
+		if err != nil {
+			t.Fatalf("ParseConfig: %v", err)
+		}
+		origLifetime := cfg.MaxConnLifetime
+		origIdle := cfg.MaxConnIdleTime
+
+		applyPoolConfig(cfg, PoolConfig{MaxConns: 50})
+
+		if cfg.MaxConns != 50 {
+			t.Errorf("MaxConns = %d, want 50", cfg.MaxConns)
+		}
+		if cfg.MaxConnLifetime != origLifetime {
+			t.Errorf("MaxConnLifetime should be untouched, got %v want %v", cfg.MaxConnLifetime, origLifetime)
+		}
+		if cfg.MaxConnIdleTime != origIdle {
+			t.Errorf("MaxConnIdleTime should be untouched, got %v want %v", cfg.MaxConnIdleTime, origIdle)
+		}
+	})
+}

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -61,13 +61,56 @@ type Store struct {
 	pool *pgxpool.Pool
 }
 
+// PoolConfig collects the pgxpool tunables the service exposes. A zero
+// field means "leave the pgxpool default in place" so callers (and
+// tests) can opt in to the knobs they care about without restating the
+// rest. The defaults pgx ships with are tuned for short-lived clients;
+// long-running services typically want a larger MaxConns and a shorter
+// MaxConnLifetime to absorb DB-side connection churn (failover, PgBouncer
+// rotations, periodic restarts).
+type PoolConfig struct {
+	// MaxConns is the upper bound on simultaneous connections.
+	// pgx default: max(4, runtime.NumCPU()).
+	MaxConns int32
+	// MinConns is how many idle connections the pool keeps warm.
+	// pgx default: 0.
+	MinConns int32
+	// MaxConnLifetime is the hard cap on a single connection's age,
+	// after which it is retired even if otherwise healthy. Useful to
+	// rotate through DB-side connection-state drift (prepared
+	// statements, search_path) and to ride out floating-IP failovers.
+	// pgx default: 1h.
+	MaxConnLifetime time.Duration
+	// MaxConnIdleTime is how long a connection may sit unused before
+	// being closed. pgx default: 30m.
+	MaxConnIdleTime time.Duration
+	// HealthCheckPeriod is how often pgx scans the pool for stale
+	// connections. pgx default: 1m.
+	HealthCheckPeriod time.Duration
+}
+
 // New opens a pgx pool against databaseURL and returns a Store that owns it.
 // Callers must call Close when done.
+//
+// New leaves the pool tunables at pgx's defaults; callers that need to
+// override them (typically the production CLI) should use NewWithPool.
 func New(ctx context.Context, databaseURL string) (*Store, error) {
+	return NewWithPool(ctx, databaseURL, PoolConfig{})
+}
+
+// NewWithPool is New plus the pool-tunable overrides described on
+// PoolConfig. Zero fields are left untouched so the per-knob defaults
+// remain whatever pgx considers sensible at the version we link.
+func NewWithPool(ctx context.Context, databaseURL string, pc PoolConfig) (*Store, error) {
 	if databaseURL == "" {
 		return nil, errors.New("store: database url is empty")
 	}
-	pool, err := pgxpool.New(ctx, databaseURL)
+	cfg, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("store: parse url: %w", err)
+	}
+	applyPoolConfig(cfg, pc)
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("store: open pool: %w", err)
 	}
@@ -76,6 +119,27 @@ func New(ctx context.Context, databaseURL string) (*Store, error) {
 		return nil, fmt.Errorf("store: ping: %w", err)
 	}
 	return &Store{pool: pool}, nil
+}
+
+// applyPoolConfig mutates cfg in place with any non-zero fields from pc.
+// Split out so tests can exercise the merge logic without standing up a
+// real Postgres.
+func applyPoolConfig(cfg *pgxpool.Config, pc PoolConfig) {
+	if pc.MaxConns > 0 {
+		cfg.MaxConns = pc.MaxConns
+	}
+	if pc.MinConns > 0 {
+		cfg.MinConns = pc.MinConns
+	}
+	if pc.MaxConnLifetime > 0 {
+		cfg.MaxConnLifetime = pc.MaxConnLifetime
+	}
+	if pc.MaxConnIdleTime > 0 {
+		cfg.MaxConnIdleTime = pc.MaxConnIdleTime
+	}
+	if pc.HealthCheckPeriod > 0 {
+		cfg.HealthCheckPeriod = pc.HealthCheckPeriod
+	}
 }
 
 // Close releases the underlying pgx pool.


### PR DESCRIPTION
Default pgx pool sizing (max(4, NumCPU) connections, 1h lifetime, 30m idle) is fine for local dev but underprovisioned for any production HTTP server: under burst load every request past the fourth queues on the pool's checkout, and a 1h lifetime keeps stale connections around through floating-IP failovers.

Plumb the four interesting knobs (max_conns, min_conns, max_conn_lifetime, max_conn_idle_time) plus health_check_period end-to-end:

  - store.PoolConfig: new struct with zero="keep pgx default" semantics so callers opt in to only the fields they care about.
  - store.NewWithPool: drop-in replacement for store.New that runs pgxpool.ParseConfig, applies overrides, then opens the pool. store.New now delegates to NewWithPool with a zero PoolConfig so the integration tests stay untouched.
  - config.Config: five new URL_SHORTENER_DB_* env vars with Validate() guards (non-negative; min <= max when both set).
  - cli/run.go: builds a PoolConfig from the loaded Config and passes it through to the store.
  - README: documents each knob with the pgx default, plus a note on when to override (PgBouncer/RDS Proxy fronting, failover).

Tests:
  - internal/store/pool_test.go: exercises applyPoolConfig in three scenarios (zero leaves defaults, full override, partial merge). Internal-package test because the merge function is unexported.
  - internal/config: TestLoad_DBPoolEnvOverrides + a table-driven TestValidate_RejectsBadDBPoolValues covering every guard.