### PR TITLE
feat(server): cap request bodies at 16 KiB via BodyLimit middleware

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -33,6 +33,16 @@ const (
 	writeTimeout      = 30 * time.Second
 	idleTimeout       = 120 * time.Second
 	shutdownTimeout   = 15 * time.Second
+
+	// maxRequestBodyBytes caps the size of any single request body
+	// the server will accept. The largest legitimate payload is the
+	// JSON create-link request, which carries at most a 2 KiB
+	// target_url plus a small envelope; 16 KiB leaves an order of
+	// magnitude of headroom while still rejecting buggy or
+	// adversarial uploads early -- before the JSON decoder allocates
+	// against them. The HTML form route is also covered because the
+	// middleware runs before any handler-level decoding.
+	maxRequestBodyBytes = 16 * 1024
 )
 
 // Deps groups the optional runtime dependencies the server needs. Each
@@ -61,6 +71,13 @@ func New(cfg config.Config, logger *slog.Logger, deps Deps) *Server {
 	e.Use(middleware.Recover())
 	e.Use(middleware.RequestID())
 	e.Use(slogRequestLogger(logger))
+	// Cap request bodies before any handler reads them. Echo's
+	// BodyLimit short-circuits with 413 Request Entity Too Large
+	// when Content-Length exceeds the cap, and wraps the body
+	// reader so chunked / unknown-length requests are caught mid-
+	// read too. Applies to every route, including the static
+	// asset handler (where bodies are always empty in practice).
+	e.Use(middleware.BodyLimit(maxRequestBodyBytes))
 
 	op := handlers.NewOperational()
 	if deps.Store != nil {

--- a/internal/server/server_integration_test.go
+++ b/internal/server/server_integration_test.go
@@ -11,6 +11,7 @@
 package server_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -150,6 +151,34 @@ func TestServer_OperationalEndpointsOverRealNetwork(t *testing.T) {
 			t.Errorf("status = %d, want 404", code)
 		}
 	})
+}
+
+func TestServer_RejectsOversizedRequestBody(t *testing.T) {
+	base, stop := startServer(t)
+	defer stop()
+
+	// 1 MiB of payload is two orders of magnitude over the 16 KiB cap;
+	// /healthz is a route that doesn't otherwise read the body, so a
+	// successful 413 here proves the BodyLimit middleware fires before
+	// the request reaches any handler. The path is irrelevant -- any
+	// route under the global middleware chain will do.
+	payload := bytes.Repeat([]byte("x"), 1<<20)
+	req, err := http.NewRequestWithContext(t.Context(),
+		http.MethodPost, base+"/healthz", bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want 413", resp.StatusCode)
+	}
 }
 
 func TestServer_GracefulShutdownClosesListener(t *testing.T) {


### PR DESCRIPTION
Reject oversized request bodies before the JSON decoder (or any handler) gets to allocate against them. The largest legitimate create-link payload is the 2 KiB target_url plus a small JSON envelope, so 16 KiB leaves an order of magnitude of headroom while still cutting off accidental or adversarial uploads early.

Echo's BodyLimit short-circuits with 413 when the Content-Length header exceeds the cap and wraps the body reader so chunked / unknown-length requests are caught mid-read. Mounted globally so every route -- API, web form, static -- inherits the same cap with no per-route opt-in.

Adds an integration test that POSTs 1 MiB to /healthz (any route under the chain works) and asserts 413, proving the middleware fires before routing.