### PR TITLE
feat(server): drain background tasks during graceful shutdown

### DIFF
--- a/internal/server/links_integration_test.go
+++ b/internal/server/links_integration_test.go
@@ -208,6 +208,107 @@ func TestLinksAPI_UnknownCodeReturns404(t *testing.T) {
 	}
 }
 
+// TestServer_GracefulShutdownDrainsBackgroundTasks proves that a click
+// fired by a request right before SIGTERM is committed before Serve
+// returns, rather than dropped along with the process. Setup is
+// inlined (rather than reusing startFullServer) because the assertion
+// has to read the underlying store *after* the server has stopped,
+// which startFullServer's t.Cleanup ordering doesn't expose cleanly.
+func TestServer_GracefulShutdownDrainsBackgroundTasks(t *testing.T) {
+	dbURL := os.Getenv("URL_SHORTENER_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("URL_SHORTENER_TEST_DATABASE_URL not set; skipping integration test")
+	}
+	redisURL := os.Getenv("URL_SHORTENER_TEST_REDIS_URL")
+	if redisURL == "" {
+		t.Skip("URL_SHORTENER_TEST_REDIS_URL not set; skipping integration test")
+	}
+
+	ctx := t.Context()
+	st, err := store.New(ctx, dbURL)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer st.Close()
+
+	cc, err := cache.New(ctx, redisURL)
+	if err != nil {
+		t.Fatalf("cache.New: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+
+	gen, err := shortener.NewGenerator(shortener.DefaultLength)
+	if err != nil {
+		t.Fatalf("shortener.NewGenerator: %v", err)
+	}
+
+	cfg := config.Config{
+		Env:        config.EnvDev,
+		Addr:       "127.0.0.1:0",
+		BaseURL:    "http://short.test",
+		LogLevel:   "info",
+		LogFormat:  "text",
+		RedisURL:   redisURL,
+		CodeLength: shortener.DefaultLength,
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := server.New(cfg, logger, server.Deps{Store: st, Cache: cc, Generator: gen})
+
+	runCtx, cancel := context.WithCancel(ctx)
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve(runCtx, ln) }()
+
+	base := "http://" + ln.Addr().String()
+	waitForReady(t, base+"/healthz")
+
+	// Seed a link so the redirect has somewhere to point. CreateLink
+	// inserts directly to skip the API layer (and its async paths).
+	target := "https://example.com/drain/" + randomSuffix(t)
+	link, err := st.CreateLink(ctx, nil, "drn"+randomSuffix(t)[:4], target, nil)
+	if err != nil {
+		t.Fatalf("CreateLink: %v", err)
+	}
+
+	// Fire the redirect. The handler returns 302 immediately and the
+	// click counter increment runs on a background goroutine that
+	// the server's drain logic must wait for.
+	rreq, _ := http.NewRequestWithContext(ctx, http.MethodGet, base+"/r/"+link.Code, nil)
+	rresp, err := httpClientNoRedirect.Do(rreq)
+	if err != nil {
+		t.Fatalf("redirect: %v", err)
+	}
+	_ = rresp.Body.Close()
+	if rresp.StatusCode != http.StatusFound {
+		t.Fatalf("redirect status = %d", rresp.StatusCode)
+	}
+
+	// Trigger graceful shutdown without giving the goroutine any
+	// extra wall-clock time first; if the drain works we still see
+	// click_count=1 below.
+	cancel()
+	select {
+	case serveErr := <-done:
+		if serveErr != nil {
+			t.Fatalf("Serve returned error: %v", serveErr)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("Serve did not return within 20s of cancellation")
+	}
+
+	got, err := st.GetLinkByCode(ctx, nil, link.Code)
+	if err != nil {
+		t.Fatalf("GetLinkByCode: %v", err)
+	}
+	if got.ClickCount != 1 {
+		t.Errorf("ClickCount = %d after shutdown, want 1 -- drain dropped the increment",
+			got.ClickCount)
+	}
+}
+
 // randomSuffix is a tiny per-test marker so concurrent runs can't share a
 // target URL. Hex of a fresh code is good enough.
 func randomSuffix(t *testing.T) string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -62,6 +62,12 @@ type Server struct {
 	deps   Deps
 	echo   *echo.Echo
 	http   *http.Server
+
+	// links is the constructed handler bundle (or nil when the
+	// caller didn't supply enough deps to mount it). Held on the
+	// server so Serve can drain its background goroutines during
+	// graceful shutdown.
+	links *handlers.Links
 }
 
 // New builds a Server with all routes and middleware mounted. It does not
@@ -95,8 +101,9 @@ func New(cfg config.Config, logger *slog.Logger, deps Deps) *Server {
 	// validation guarantees URL_SHORTENER_REDIS_URL is set in production).
 	// The HTML web UI (form + recent list) is mounted alongside whenever
 	// the API is up; both reuse the same underlying *handlers.Links.
+	var links *handlers.Links
 	if deps.Store != nil && deps.Cache != nil && deps.Generator != nil {
-		links := handlers.NewLinks(handlers.LinksConfig{
+		links = handlers.NewLinks(handlers.LinksConfig{
 			Store:     deps.Store,
 			Cache:     deps.Cache,
 			Generator: deps.Generator,
@@ -128,7 +135,7 @@ func New(cfg config.Config, logger *slog.Logger, deps Deps) *Server {
 		IdleTimeout:       idleTimeout,
 	}
 
-	return &Server{cfg: cfg, logger: logger, deps: deps, echo: e, http: httpSrv}
+	return &Server{cfg: cfg, logger: logger, deps: deps, echo: e, http: httpSrv, links: links}
 }
 
 // Run starts the HTTP server and blocks until ctx is cancelled (typically by
@@ -169,11 +176,47 @@ func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
-	if err := s.http.Shutdown(shutdownCtx); err != nil {
-		return fmt.Errorf("server: shutdown: %w", err)
+	shutdownErr := s.http.Shutdown(shutdownCtx)
+
+	// Drain background goroutines (currently just async click counter
+	// increments) before reporting shutdown complete. Any work fired
+	// from a request that landed before Shutdown() drew the curtain
+	// gets a chance to commit; without this drain SIGTERM can drop
+	// the last few clicks every deploy. We use whatever budget is
+	// left in shutdownCtx -- typically most of the 15s, since
+	// http.Shutdown returns as soon as the last in-flight request
+	// finishes -- so the overall stop time is still bounded.
+	if s.links != nil {
+		remaining := timeUntil(shutdownCtx)
+		if remaining > 0 {
+			if !s.links.WaitForBackgroundTasks(remaining) {
+				s.logger.Warn("background tasks did not drain before shutdown deadline",
+					"budget", remaining)
+			}
+		}
+	}
+
+	if shutdownErr != nil {
+		return fmt.Errorf("server: shutdown: %w", shutdownErr)
 	}
 	s.logger.Info("http server stopped")
 	return nil
+}
+
+// timeUntil returns the duration left until ctx's deadline, or 0 when
+// the deadline has already passed (or no deadline is set, in which
+// case there's no budget to allocate to drain). Split out so the
+// shutdown path stays readable.
+func timeUntil(ctx context.Context) time.Duration {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return 0
+	}
+	remaining := time.Until(deadline)
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
 }
 
 // slogRequestLogger returns Echo middleware that logs each request via slog.


### PR DESCRIPTION
The fire-and-forget click-counter goroutines started by Links.Redirect already had a WaitGroup hook (Links.WaitForBackgroundTasks) but nothing in the server lifecycle waited on it. SIGTERM would http.Shutdown the listener and immediately return, terminating any in-flight click increment along with the process. Under steady traffic, every rolling deploy lost the last few clicks per pod.

Wire the existing hook into Server.Serve:

  - Server holds the *handlers.Links it constructed (or nil when the dep set is partial), so the shutdown path can reach it without re-deriving anything.
  - After http.Shutdown returns, drain the WaitGroup with whatever budget is left in shutdownCtx (typically most of the 15s, since Shutdown returns as soon as the last in-flight request finishes). A timed-out drain logs at warn but does not fail the shutdown -- the process is leaving anyway.
  - timeUntil() helper extracts the deadline-math so the shutdown path stays linear.

Integration test seeds a link, fires a single redirect, cancels the run context immediately (no sleep), and asserts click_count=1 after Serve returns. Without the drain the click is lost; with it, the goroutine completes before Serve unblocks.