### PR TITLE
feat(api): add structured error_code to JSON error responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,26 @@ expired code (returned by both `GET /api/v1/links/:code` and
 `GET /r/:code` -- distinct from `404` so clients can tell a once-valid
 code from one that never existed).
 
+Error responses carry a stable `code` field alongside the
+human-readable `error` so clients can branch on the failure without
+parsing the message:
+
+```json
+{ "error": "code already in use", "code": "code_taken" }
+```
+
+| HTTP | `code`              | When                                                      |
+| ---- | ------------------- | --------------------------------------------------------- |
+| 400  | `invalid_json_body` | Request body is not parseable JSON.                       |
+| 422  | `validation_failed` | Input failed a validation rule (URL, code, or expiry).    |
+| 409  | `code_taken`        | The user-supplied short code is already in use.           |
+| 404  | `not_found`         | The code does not exist (either malformed or unknown).    |
+| 410  | `link_expired`      | The link existed but its `expires_at` has passed.         |
+| 500  | `internal_error`    | Any other server-side failure; details are logged only.   |
+
+The string values are part of the public API contract and will not
+change once published; new codes may be added.
+
 ### Deduplication
 
 Auto-generated codes are idempotent on the (normalized) target URL: a

--- a/internal/handlers/links.go
+++ b/internal/handlers/links.go
@@ -154,9 +154,35 @@ type LinkResponse struct {
 	ExpiresAt  *time.Time `json:"expires_at,omitempty"`
 }
 
-// ErrorResponse is the JSON shape returned for any non-2xx response.
+// ErrorResponse is the JSON shape returned for any non-2xx response from
+// the JSON API. The Error field is the human-readable description (safe
+// to surface in a UI); Code is a stable machine-readable identifier
+// suitable for client-side branching, metric labels, and i18n keys. The
+// pair is set together via errResp; callers should never construct an
+// ErrorResponse with one field and not the other.
 type ErrorResponse struct {
 	Error string `json:"error"`
+	Code  string `json:"code"`
+}
+
+// API error codes. These strings are part of the public API contract:
+// once published, the values must not change (clients may switch on
+// them). Adding new codes is fine; renaming or removing an existing one
+// is a breaking change and warrants a major-version bump.
+const (
+	ErrCodeInvalidJSONBody = "invalid_json_body" // 400 on POST when the body is not parseable JSON.
+	ErrCodeValidation      = "validation_failed" // 422 when input fails our rules (bad URL, bad code, bad expiry).
+	ErrCodeCodeTaken       = "code_taken"        // 409 when a user-supplied short code is already in use.
+	ErrCodeNotFound        = "not_found"         // 404 when the requested code does not exist.
+	ErrCodeLinkExpired     = "link_expired"      // 410 when the link existed but has passed its expires_at.
+	ErrCodeInternal        = "internal_error"    // 500 for any other failure.
+)
+
+// errResp builds an ErrorResponse with both fields set. Centralised so
+// every call site is forced to provide a code, preventing the public
+// shape from drifting back into "human message only".
+func errResp(code, msg string) ErrorResponse {
+	return ErrorResponse{Error: msg, Code: code}
 }
 
 // --- service-level helpers (exposed for the web handler) -------------------
@@ -326,7 +352,7 @@ func (h *Links) Response(l store.Link) LinkResponse { return h.makeResp(l) }
 func (h *Links) Create(c *echo.Context) error {
 	var req createReq
 	if err := json.NewDecoder(c.Request().Body).Decode(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid json body"})
+		return c.JSON(http.StatusBadRequest, errResp(ErrCodeInvalidJSONBody, "invalid json body"))
 	}
 
 	link, created, err := h.Persist(c.Request().Context(), req.TargetURL, req.Code, req.ExpiresAt)
@@ -334,11 +360,11 @@ func (h *Links) Create(c *echo.Context) error {
 	case PersistErrNone:
 		// fall through to the success response below
 	case PersistErrValidation:
-		return c.JSON(status, ErrorResponse{Error: msg})
+		return c.JSON(status, errResp(ErrCodeValidation, msg))
 	case PersistErrCodeTaken:
-		return c.JSON(status, ErrorResponse{Error: "code already in use"})
+		return c.JSON(status, errResp(ErrCodeCodeTaken, "code already in use"))
 	case PersistErrInternal:
-		return c.JSON(status, ErrorResponse{Error: "internal error"})
+		return c.JSON(status, errResp(ErrCodeInternal, "internal error"))
 	}
 	status := http.StatusCreated
 	if !created {
@@ -374,18 +400,18 @@ func (h *Links) createWithRandomCode(ctx context.Context, target string, expires
 func (h *Links) Get(c *echo.Context) error {
 	code := c.Param("code")
 	if !shortener.ValidCode(code) {
-		return c.JSON(http.StatusNotFound, ErrorResponse{Error: "not found"})
+		return c.JSON(http.StatusNotFound, errResp(ErrCodeNotFound, "not found"))
 	}
 	link, err := h.store.GetLinkByCode(c.Request().Context(), nil, code)
 	if errors.Is(err, store.ErrNotFound) {
-		return c.JSON(http.StatusNotFound, ErrorResponse{Error: "not found"})
+		return c.JSON(http.StatusNotFound, errResp(ErrCodeNotFound, "not found"))
 	}
 	if err != nil {
 		h.logger.Error("links: get failed", "error", err, "code", code)
-		return c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "internal error"})
+		return c.JSON(http.StatusInternalServerError, errResp(ErrCodeInternal, "internal error"))
 	}
 	if link.IsExpired() {
-		return c.JSON(http.StatusGone, ErrorResponse{Error: "link has expired"})
+		return c.JSON(http.StatusGone, errResp(ErrCodeLinkExpired, "link has expired"))
 	}
 	return c.JSON(http.StatusOK, h.makeResp(link))
 }

--- a/internal/handlers/links_test.go
+++ b/internal/handlers/links_test.go
@@ -303,8 +303,12 @@ func TestCreate_DuplicateUserSuppliedCodeReturns409(t *testing.T) {
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("status = %d, body = %s", rec.Code, string(body))
 	}
-	if got := decodeError(t, body).Error; got == "" {
+	got := decodeError(t, body)
+	if got.Error == "" {
 		t.Errorf("expected non-empty error message")
+	}
+	if got.Code != handlers.ErrCodeCodeTaken {
+		t.Errorf("error code = %q, want %q", got.Code, handlers.ErrCodeCodeTaken)
 	}
 }
 
@@ -432,23 +436,27 @@ func TestCreate_BadInputReturns4xx(t *testing.T) {
 	tests := []struct {
 		name, body string
 		wantStatus int
+		wantCode   string
 	}{
-		{"invalid_json", `{not json`, http.StatusBadRequest},
-		{"missing_target_url", `{}`, http.StatusUnprocessableEntity},
-		{"empty_target_url", `{"target_url":""}`, http.StatusUnprocessableEntity},
-		{"non_http_scheme", `{"target_url":"ftp://x.example"}`, http.StatusUnprocessableEntity},
-		{"no_host", `{"target_url":"http://"}`, http.StatusUnprocessableEntity},
-		{"too_long", `{"target_url":"https://x.example/` + strings.Repeat("a", 2100) + `"}`, http.StatusUnprocessableEntity},
-		{"bad_user_code", `{"target_url":"https://x.example","code":"!!!"}`, http.StatusUnprocessableEntity},
+		{"invalid_json", `{not json`, http.StatusBadRequest, handlers.ErrCodeInvalidJSONBody},
+		{"missing_target_url", `{}`, http.StatusUnprocessableEntity, handlers.ErrCodeValidation},
+		{"empty_target_url", `{"target_url":""}`, http.StatusUnprocessableEntity, handlers.ErrCodeValidation},
+		{"non_http_scheme", `{"target_url":"ftp://x.example"}`, http.StatusUnprocessableEntity, handlers.ErrCodeValidation},
+		{"no_host", `{"target_url":"http://"}`, http.StatusUnprocessableEntity, handlers.ErrCodeValidation},
+		{"too_long", `{"target_url":"https://x.example/` + strings.Repeat("a", 2100) + `"}`, http.StatusUnprocessableEntity, handlers.ErrCodeValidation},
+		{"bad_user_code", `{"target_url":"https://x.example","code":"!!!"}`, http.StatusUnprocessableEntity, handlers.ErrCodeValidation},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			st, cc := newFakeStore(), newFakeCache()
 			e, _ := newHandlerWithCache(t, st, cc, &scriptedGen{codes: []string{"unused0"}})
-			rec, _ := doJSON(t, e, http.MethodPost, "/api/v1/links", tt.body)
+			rec, body := doJSON(t, e, http.MethodPost, "/api/v1/links", tt.body)
 			if rec.Code != tt.wantStatus {
 				t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if got := decodeError(t, body); got.Code != tt.wantCode {
+				t.Errorf("error code = %q, want %q (body=%s)", got.Code, tt.wantCode, body)
 			}
 		})
 	}
@@ -481,9 +489,12 @@ func TestGet_UnknownCodeReturns404(t *testing.T) {
 	t.Parallel()
 	st, cc := newFakeStore(), newFakeCache()
 	e, _ := newHandlerWithCache(t, st, cc, &scriptedGen{})
-	rec, _ := doJSON(t, e, http.MethodGet, "/api/v1/links/missing", "")
+	rec, body := doJSON(t, e, http.MethodGet, "/api/v1/links/missing", "")
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", rec.Code)
+	}
+	if got := decodeError(t, body); got.Code != handlers.ErrCodeNotFound {
+		t.Errorf("error code = %q, want %q", got.Code, handlers.ErrCodeNotFound)
 	}
 }
 
@@ -648,9 +659,12 @@ func TestGet_ExpiredLinkReturns410(t *testing.T) {
 	}
 	e, _ := newHandlerWithCache(t, st, cc, &scriptedGen{})
 
-	rec, _ := doJSON(t, e, http.MethodGet, "/api/v1/links/expired", "")
+	rec, body := doJSON(t, e, http.MethodGet, "/api/v1/links/expired", "")
 	if rec.Code != http.StatusGone {
 		t.Errorf("status = %d, want 410", rec.Code)
+	}
+	if got := decodeError(t, body); got.Code != handlers.ErrCodeLinkExpired {
+		t.Errorf("error code = %q, want %q", got.Code, handlers.ErrCodeLinkExpired)
 	}
 }
 


### PR DESCRIPTION
The JSON API used to return only a free-form 'error' string, which forced clients to grep error messages to branch on the failure. Add a sibling 'code' field with a stable, machine-readable identifier that's safe to switch on and to use as a metric label / i18n key.

Public contract additions in handlers.ErrorResponse:

  - Error string  // human-readable, may change wording
  - Code  string  // stable enum: invalid_json_body | validation_failed
                  //              code_taken | not_found | link_expired
                  //              | internal_error

Each value is exported as a top-level constant (handlers.ErrCode*) so consumers inside the module can reference them without typo risk. The README spells out the HTTP+code mapping and the non-breaking-change policy.

A new errResp(code, msg) constructor is the only path that builds an ErrorResponse, so future call sites can't drop back to setting just one field; every existing JSON error site in links.go was migrated to call it.

Tests:
  - TestCreate_BadInputReturns4xx now table-asserts the expected code per case (invalid JSON -> invalid_json_body, validation cases -> validation_failed).
  - TestCreate_DuplicateUserSuppliedCodeReturns409, TestGet_*404 and TestGet_ExpiredLinkReturns410 each pin the corresponding code so accidental rewording can't silently break clients.

The HTML web handler is unchanged -- its error rendering is HTML fragments, not JSON, and exposing structured codes there has no downstream consumer.