### PR TITLE
feat(handlers): retry transient DB errors on click increment with backoff+jitter

### DIFF
--- a/internal/handlers/links.go
+++ b/internal/handlers/links.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math/rand/v2"
 	"net/http"
 	"net/url"
 	"strings"
@@ -40,6 +41,20 @@ const (
 	// the database, short enough that a permanently degraded DB
 	// can't pin goroutines around forever under sustained traffic.
 	clickTimeout = 5 * time.Second
+
+	// Click-increment retry schedule for transient DB failures
+	// (deadlock_detected etc.). The increment is detached, so the
+	// retries don't add user-visible latency; the budget below stays
+	// well inside clickTimeout even at the cap.
+	//
+	//   attempt 1: immediate
+	//   attempt 2: ~50ms +/- 25ms
+	//   attempt 3: ~100ms +/- 50ms
+	//   attempt 4: ~200ms +/- 100ms
+	//   attempt 5: ~400ms +/- 200ms  (worst case ~750ms total)
+	clickRetryAttempts   = 5
+	clickRetryBaseDelay  = 50 * time.Millisecond
+	clickRetryMaxBackoff = 1 * time.Second
 
 	// clockSkewGrace is the leniency applied when validating a
 	// caller-supplied expires_at: a few seconds in the past is
@@ -460,16 +475,73 @@ func (h *Links) Redirect(c *echo.Context) error {
 // without bound. The WaitGroup makes it possible for tests (and a
 // future graceful-shutdown path) to wait for in-flight clicks; in
 // production we don't otherwise observe it.
+//
+// Transient DB errors (deadlock, serialization failure, statement
+// completion unknown) are retried with exponential backoff + jitter
+// inside the goroutine; non-transient errors and exhausted budgets
+// are logged and dropped, since the click counter is best-effort.
 func (h *Links) recordClick(code string) {
 	h.bgWG.Add(1)
 	go func() {
 		defer h.bgWG.Done()
 		ctx, cancel := context.WithTimeout(context.Background(), clickTimeout)
 		defer cancel()
-		if err := h.store.IncrementClicks(ctx, nil, code); err != nil {
+		if err := h.incrementClicksWithRetry(ctx, code); err != nil {
 			h.logger.Warn("links: increment clicks failed", "error", err, "code", code)
 		}
 	}()
+}
+
+// incrementClicksWithRetry calls store.IncrementClicks with bounded
+// exponential backoff (jittered) on transient errors. It returns the
+// last error observed (or nil on success). The function is unexported
+// because the retry policy is bespoke to this call site -- the
+// counter is idempotent under repeated UPDATE, so re-issuing an
+// ambiguously-completed statement is safe.
+func (h *Links) incrementClicksWithRetry(ctx context.Context, code string) error {
+	var err error
+	backoff := clickRetryBaseDelay
+	for attempt := 1; attempt <= clickRetryAttempts; attempt++ {
+		err = h.store.IncrementClicks(ctx, nil, code)
+		if err == nil {
+			return nil
+		}
+		if !store.IsTransient(err) {
+			return err
+		}
+		if attempt == clickRetryAttempts {
+			break
+		}
+		// Sleep before the next attempt; bail early if the caller's
+		// context (clickTimeout) expires while we wait. Returning the
+		// most recent transient err -- not ctx.Err() -- gives the log
+		// line a more useful root-cause for an operator scanning for
+		// 40P01 spikes.
+		select {
+		case <-ctx.Done():
+			return err
+		case <-time.After(jitter(backoff)):
+		}
+		backoff *= 2
+		if backoff > clickRetryMaxBackoff {
+			backoff = clickRetryMaxBackoff
+		}
+	}
+	return err
+}
+
+// jitter returns d randomized within [d/2, 3d/2). Decorrelated jitter
+// would smear retries even more uniformly, but for a single-instance
+// best-effort counter the simpler full-range jitter is plenty.
+func jitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	half := d / 2
+	// rand.Int64N panics on n<=0; the d>0 guard above keeps us safe.
+	// math/rand/v2 is the right tool here -- the jitter only needs to
+	// decorrelate retries across goroutines, not resist prediction.
+	return half + time.Duration(rand.Int64N(int64(d))) //nolint:gosec // non-cryptographic jitter
 }
 
 // WaitForBackgroundTasks blocks until every recordClick goroutine

--- a/internal/handlers/links_test.go
+++ b/internal/handlers/links_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/labstack/echo/v5"
 
 	"github.com/vancanhuit/url-shortener/internal/handlers"
@@ -25,12 +26,14 @@ import (
 // fakeStore implements handlers.LinkStore against an in-memory map. It also
 // records inserts so the auto-collision retry test can force collisions.
 type fakeStore struct {
-	mu       sync.Mutex
-	links    map[string]store.Link
-	clicks   map[string]int64 // separate counter so tests can poll without racing on links[]
-	nextID   int64
-	failNew  error // non-nil makes the next CreateLink return failNew
-	failList error // non-nil makes every ListLinks return failList
+	mu         sync.Mutex
+	links      map[string]store.Link
+	clicks     map[string]int64 // separate counter so tests can poll without racing on links[]
+	clickErrs  []error          // queued errors returned by IncrementClicks; popped per call. nil entries pass through to the real bump.
+	clickCalls int              // total IncrementClicks invocations (success + failure), for retry-budget assertions.
+	nextID     int64
+	failNew    error // non-nil makes the next CreateLink return failNew
+	failList   error // non-nil makes every ListLinks return failList
 }
 
 func newFakeStore() *fakeStore {
@@ -68,6 +71,14 @@ func (f *fakeStore) CreateLink(_ context.Context, _ store.DBTX, code, target str
 func (f *fakeStore) IncrementClicks(_ context.Context, _ store.DBTX, code string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.clickCalls++
+	if len(f.clickErrs) > 0 {
+		err := f.clickErrs[0]
+		f.clickErrs = f.clickErrs[1:]
+		if err != nil {
+			return err
+		}
+	}
 	f.clicks[code]++
 	if l, ok := f.links[code]; ok {
 		l.ClickCount = f.clicks[code]
@@ -696,6 +707,80 @@ func TestRedirect_IncrementsClickCount(t *testing.T) {
 	st.mu.Unlock()
 	if got != 3 {
 		t.Errorf("clicks = %d, want 3", got)
+	}
+}
+
+// TestRedirect_RetriesTransientClickFailure: a deadlock_detected on
+// the first IncrementClicks attempt must be retried (with backoff) and
+// eventually succeed; the click counter ends up incremented exactly
+// once and a non-trivial number of attempts is observed.
+func TestRedirect_RetriesTransientClickFailure(t *testing.T) {
+	t.Parallel()
+	st, cc := newFakeStore(), newFakeCache()
+	if _, err := st.CreateLink(context.Background(), nil, "retried", "https://r.example", nil); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// Two transient failures, then nil (success). The click counter
+	// should still end at 1, and IncrementClicks should have been
+	// invoked exactly three times.
+	st.clickErrs = []error{
+		&pgconn.PgError{Code: "40P01", Message: "deadlock_detected"},
+		&pgconn.PgError{Code: "40001", Message: "serialization_failure"},
+		nil,
+	}
+	e, h := newHandlerWithCache(t, st, cc, &scriptedGen{})
+
+	req := httptest.NewRequest(http.MethodGet, "/r/retried", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("redirect status = %d", rec.Code)
+	}
+	if !h.WaitForBackgroundTasks(2 * time.Second) {
+		t.Fatal("click goroutine did not complete in time (retry budget exceeded?)")
+	}
+
+	st.mu.Lock()
+	calls, count := st.clickCalls, st.clicks["retried"]
+	st.mu.Unlock()
+	if calls != 3 {
+		t.Errorf("IncrementClicks calls = %d, want 3 (initial + two retries)", calls)
+	}
+	if count != 1 {
+		t.Errorf("click count = %d, want 1", count)
+	}
+}
+
+// TestRedirect_DoesNotRetryNonTransientClickFailure: a non-pg error
+// (or one with a non-retryable SQLSTATE) must NOT be retried. The
+// counter stays at zero and exactly one attempt is recorded.
+func TestRedirect_DoesNotRetryNonTransientClickFailure(t *testing.T) {
+	t.Parallel()
+	st, cc := newFakeStore(), newFakeCache()
+	if _, err := st.CreateLink(context.Background(), nil, "noretry", "https://n.example", nil); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	st.clickErrs = []error{errors.New("some other error")}
+	e, h := newHandlerWithCache(t, st, cc, &scriptedGen{})
+
+	req := httptest.NewRequest(http.MethodGet, "/r/noretry", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("redirect status = %d", rec.Code)
+	}
+	if !h.WaitForBackgroundTasks(2 * time.Second) {
+		t.Fatal("click goroutine did not complete in time")
+	}
+
+	st.mu.Lock()
+	calls, count := st.clickCalls, st.clicks["noretry"]
+	st.mu.Unlock()
+	if calls != 1 {
+		t.Errorf("IncrementClicks calls = %d, want 1 (no retry on non-transient)", calls)
+	}
+	if count != 0 {
+		t.Errorf("click count = %d, want 0 (failed increment must not bump counter)", count)
 	}
 }
 

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -27,6 +27,54 @@ var ErrCodeTaken = errors.New("store: code already taken")
 // uniqueViolation is the Postgres SQLSTATE for a unique-constraint violation.
 const uniqueViolation = "23505"
 
+// Transient SQLSTATE codes recognised by IsTransient. The list is
+// intentionally narrow: every entry must describe a failure that is
+// safe to retry against an idempotent statement without changing the
+// observed semantics. We deliberately exclude
+//
+//   - 40002 (transaction_integrity_constraint_violation): a constraint
+//     check failed; retrying produces the same result, so this is a
+//     real input-shape error, not a transient one.
+//   - the 08* connection-exception class: pgxpool already reconnects
+//     transparently when checking out a fresh connection; an 08* that
+//     reaches the caller means the in-flight statement was lost
+//     mid-flight and we don't know whether it committed.
+const (
+	sqlstateSerializationFailure       = "40001"
+	sqlstateStatementCompletionUnknown = "40003"
+	sqlstateDeadlockDetected           = "40P01"
+)
+
+// IsTransient reports whether err is a transient database failure that
+// is safe to retry against an idempotent operation. Currently this
+// covers serialization failures, deadlock detections, and statement-
+// completion-unknown -- the SQLSTATE codes Postgres uses to signal
+// "give it another go and it might just work" against READ COMMITTED
+// or higher isolation. Any other error -- including a nil error -- is
+// classified as non-transient.
+//
+// Callers should keep retries bounded (count + total time budget) and
+// only apply this on operations that are safe to repeat: the increment
+// counter is the canonical example. Do not retry write paths whose
+// idempotency depends on application-level invariants without thinking
+// through the failure modes first.
+func IsTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	switch pgErr.Code {
+	case sqlstateSerializationFailure,
+		sqlstateStatementCompletionUnknown,
+		sqlstateDeadlockDetected:
+		return true
+	}
+	return false
+}
+
 // DBTX is satisfied by *pgxpool.Pool (and pgxpool.Conn) as well as pgx.Tx,
 // allowing store methods to participate in caller-managed transactions.
 type DBTX interface {

--- a/internal/store/transient_test.go
+++ b/internal/store/transient_test.go
@@ -1,0 +1,53 @@
+package store_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/vancanhuit/url-shortener/internal/store"
+)
+
+// TestIsTransient walks every SQLSTATE class we care about so the
+// classifier can't silently widen or narrow without flipping a test.
+// Uses external_test (store_test) intentionally: IsTransient is part
+// of the package's public surface and behaviour.
+func TestIsTransient(t *testing.T) {
+	t.Parallel()
+
+	pgErr := func(code string) error {
+		return &pgconn.PgError{Code: code, Message: "synthetic " + code}
+	}
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"non-pg error", errors.New("boom"), false},
+		{"unique violation", pgErr("23505"), false},
+		{"check violation", pgErr("23514"), false},
+		{"connection exception", pgErr("08000"), false}, // pgxpool handles, see doc comment
+		{"connection failure", pgErr("08006"), false},
+		{"integrity violation in tx-rollback class", pgErr("40002"), false},
+		{"serialization failure", pgErr("40001"), true},
+		{"statement completion unknown", pgErr("40003"), true},
+		{"deadlock detected", pgErr("40P01"), true},
+		// Wrapped transient stays transient.
+		{"wrapped deadlock", fmt.Errorf("calling x: %w", pgErr("40P01")), true},
+		// Wrapped non-transient stays non-transient.
+		{"wrapped unique", fmt.Errorf("calling x: %w", pgErr("23505")), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := store.IsTransient(tc.err); got != tc.want {
+				t.Errorf("IsTransient(%v) = %t, want %t", tc.err, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Under steady traffic the click counter UPDATE is the most contended write in the system: every redirect bumps the same row, and bursts of clicks on a single popular link can collide on row locks long enough to surface a 40P01 deadlock_detected. Today the goroutine logs the warning and drops the click on the floor.

Add a narrow transient-error retry on this exact path:

  - store.IsTransient(err): tests pgconn.PgError.Code against three SQLSTATEs that Postgres uses to mean 'idempotent retry safe': 40001 serialization_failure, 40003 statement_completion_unknown, 40P01 deadlock_detected. We deliberately exclude 40002 (real integrity violation) and the 08* class (pgxpool already swaps in a fresh conn; an 08 reaching us means we lost the statement).

  - handlers.incrementClicksWithRetry: wraps store.IncrementClicks with an exponential backoff schedule (50ms, 100ms, 200ms, 400ms, capped at 1s) jittered to [d/2, 3d/2). Up to 5 attempts within the existing 5s clickTimeout budget. Bails immediately on a non-transient error or on ctx cancellation. The retries live inside the detached goroutine so they add zero user-visible latency.

  - jitter() uses math/rand/v2 (decorrelating retries across goroutines is the only requirement; no security property).

The auto-generated-code retry loop in createWithRandomCode is left spinning -- each attempt independently re-rolls a fresh random code from a 62^7 keyspace, so backoff there would only add tail latency without changing the success probability of the next draw.

Tests:
  - store/transient_test.go: table-tests IsTransient against every interesting SQLSTATE class (and wrapped errors).
  - handlers: TestRedirect_RetriesTransientClickFailure scripts two transient failures + one success, asserts 3 IncrementClicks calls and final click_count==1.
  - handlers: TestRedirect_DoesNotRetryNonTransientClickFailure scripts a generic error and asserts a single attempt.