### PR TITLE
feat(config): require database_url, drop optional-DB path in run

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -87,7 +87,7 @@ test:
 # URLs are hard-coded against the `test`-profile services in compose.yaml
 # (db-test on host port 5433, redis-test on 6380); update both files
 # together if those ports ever change.
-test-integration: build
+test-integration:
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -95,7 +95,6 @@ test-integration: build
     export URL_SHORTENER_TEST_REDIS_URL='redis://localhost:6380/0'
 
     docker compose --profile=test up --wait --detach db-test redis-test
-    ./bin/url-shortener migrate up --database-url "$URL_SHORTENER_TEST_DATABASE_URL"
     go test -race -v -cover -tags=integration ./...
 
 # Install golangci-lint v{{GOLANGCI_LINT_VERSION}} into $GOPATH/bin.

--- a/Justfile
+++ b/Justfile
@@ -93,8 +93,8 @@ test-integration: build
 
     export URL_SHORTENER_TEST_DATABASE_URL='postgres://postgres:postgres@localhost:5433/url_shortener?sslmode=disable'
     export URL_SHORTENER_TEST_REDIS_URL='redis://localhost:6380/0'
-    ./bin/url-shortener migrate up --database-url "$URL_SHORTENER_TEST_DATABASE_URL"
     docker compose --profile=test up --wait --detach db-test redis-test
+    ./bin/url-shortener migrate up --database-url "$URL_SHORTENER_TEST_DATABASE_URL"
     go test -race -v -cover -tags=integration ./...
 
 # Install golangci-lint v{{GOLANGCI_LINT_VERSION}} into $GOPATH/bin.

--- a/Justfile
+++ b/Justfile
@@ -87,13 +87,13 @@ test:
 # URLs are hard-coded against the `test`-profile services in compose.yaml
 # (db-test on host port 5433, redis-test on 6380); update both files
 # together if those ports ever change.
-test-integration:
+test-integration: build
     #!/usr/bin/env bash
     set -euo pipefail
 
     export URL_SHORTENER_TEST_DATABASE_URL='postgres://postgres:postgres@localhost:5433/url_shortener?sslmode=disable'
     export URL_SHORTENER_TEST_REDIS_URL='redis://localhost:6380/0'
-
+    ./bin/url-shortener migrate up --database-url "$URL_SHORTENER_TEST_DATABASE_URL"
     docker compose --profile=test up --wait --detach db-test redis-test
     go test -race -v -cover -tags=integration ./...
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -32,31 +32,25 @@ func newRunCmd() *cobra.Command {
 			}
 			logger.Info("starting url-shortener", "env", cfg.Env, "addr", cfg.Addr)
 
-			// Database and cache are both optional: /healthz answers without
-			// either, and /readyz simply omits checks for missing deps. This
-			// keeps first-boot smoke tests friendly.
-			var st *store.Store
-			if cfg.DatabaseURL != "" {
-				if cfg.AutoMigrate {
-					logger.Info("auto_migrate=true; applying migrations before serving")
-					if err := migrate.Up(cmd.Context(), cfg.DatabaseURL); err != nil {
-						return err
-					}
-				}
-				st, err = store.NewWithPool(cmd.Context(), cfg.DatabaseURL, store.PoolConfig{
-					MaxConns:          cfg.DBMaxConns,
-					MinConns:          cfg.DBMinConns,
-					MaxConnLifetime:   cfg.DBMaxConnLifetime,
-					MaxConnIdleTime:   cfg.DBMaxConnIdleTime,
-					HealthCheckPeriod: cfg.DBHealthCheckPeriod,
-				})
-				if err != nil {
+			// Postgres is a required runtime dependency (enforced by
+			// config.Validate); DatabaseURL is guaranteed non-empty here.
+			if cfg.AutoMigrate {
+				logger.Info("auto_migrate=true; applying migrations before serving")
+				if err := migrate.Up(cmd.Context(), cfg.DatabaseURL); err != nil {
 					return err
 				}
-				defer st.Close()
-			} else {
-				logger.Warn("URL_SHORTENER_DATABASE_URL is empty; running without a database")
 			}
+			st, err := store.NewWithPool(cmd.Context(), cfg.DatabaseURL, store.PoolConfig{
+				MaxConns:          cfg.DBMaxConns,
+				MinConns:          cfg.DBMinConns,
+				MaxConnLifetime:   cfg.DBMaxConnLifetime,
+				MaxConnIdleTime:   cfg.DBMaxConnIdleTime,
+				HealthCheckPeriod: cfg.DBHealthCheckPeriod,
+			})
+			if err != nil {
+				return err
+			}
+			defer st.Close()
 
 			// Redis is a required dependency (enforced by config.Validate),
 			// so RedisURL is guaranteed to be non-empty here.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -148,6 +148,12 @@ func (c Config) Validate() error {
 	if _, err := url.Parse(c.BaseURL); err != nil {
 		return fmt.Errorf("config: base_url is not a valid URL: %w", err)
 	}
+	// Postgres is a required runtime dependency: the link store is the
+	// system of record. Refuse to start instead of booting a server that
+	// would 500 on every request.
+	if c.DatabaseURL == "" {
+		return fmt.Errorf("config: database_url must not be empty")
+	}
 	// Redis is a required runtime dependency: the cache is on the hot path
 	// for redirect lookups and the API treats it as always-present. Refuse
 	// to start instead of silently degrading.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,7 +11,9 @@ import (
 
 func TestLoad_Defaults(t *testing.T) {
 	clearEnv(t)
-	// Redis is a required field; set the minimum needed for Load() to succeed.
+	// Postgres + Redis are required fields; set the minimum needed for
+	// Load() to succeed.
+	t.Setenv("URL_SHORTENER_DATABASE_URL", "postgres://u:p@h:5432/db")
 	t.Setenv("URL_SHORTENER_REDIS_URL", "redis://localhost:6379/0")
 
 	cfg, err := config.Load()
@@ -39,6 +41,7 @@ func TestLoad_Defaults(t *testing.T) {
 func TestLoad_DevDefaultsLogFormatToText(t *testing.T) {
 	clearEnv(t)
 	t.Setenv("URL_SHORTENER_ENV", "dev")
+	t.Setenv("URL_SHORTENER_DATABASE_URL", "postgres://u:p@h:5432/db")
 	t.Setenv("URL_SHORTENER_REDIS_URL", "redis://localhost:6379/0")
 
 	cfg, err := config.Load()
@@ -85,6 +88,7 @@ func TestLoad_EnvOverrides(t *testing.T) {
 
 func TestLoad_DBPoolEnvOverrides(t *testing.T) {
 	clearEnv(t)
+	t.Setenv("URL_SHORTENER_DATABASE_URL", "postgres://u:p@h:5432/db")
 	t.Setenv("URL_SHORTENER_REDIS_URL", "redis://localhost:6379/0")
 	t.Setenv("URL_SHORTENER_DB_MAX_CONNS", "32")
 	t.Setenv("URL_SHORTENER_DB_MIN_CONNS", "4")
@@ -117,11 +121,15 @@ func TestLoad_DBPoolEnvOverrides(t *testing.T) {
 func TestValidate_RejectsBadDBPoolValues(t *testing.T) {
 	t.Parallel()
 
-	const redisOK = "redis://localhost:6379/0"
+	const (
+		redisURL    = "redis://localhost:6379/0"
+		databaseURL = "postgres://u:p@h:5432/db"
+	)
 	base := func() config.Config {
 		return config.Config{
 			Env: "prod", Addr: ":8080", BaseURL: "x",
-			LogLevel: "info", LogFormat: "json", RedisURL: redisOK,
+			LogLevel: "info", LogFormat: "json",
+			DatabaseURL: databaseURL, RedisURL: redisURL,
 		}
 	}
 
@@ -151,16 +159,21 @@ func TestValidate_RejectsBadDBPoolValues(t *testing.T) {
 func TestValidate_RejectsBadValues(t *testing.T) {
 	t.Parallel()
 
-	// Every case sets a non-empty RedisURL so the failure is attributable to
-	// the field under test, except for the dedicated empty-redis case.
-	const redisOK = "redis://localhost:6379/0"
+	// Every case sets non-empty DatabaseURL + RedisURL so the failure is
+	// attributable to the field under test, except for the dedicated
+	// empty-database-url and empty-redis-url cases.
+	const (
+		redisURL    = "redis://localhost:6379/0"
+		databaseURL = "postgres://u:p@h:5432/db"
+	)
 	cases := map[string]config.Config{
-		"bad env":         {Env: "staging", Addr: ":8080", BaseURL: "x", LogLevel: "info", LogFormat: "json", RedisURL: redisOK},
-		"bad log_level":   {Env: "prod", Addr: ":8080", BaseURL: "x", LogLevel: "trace", LogFormat: "json", RedisURL: redisOK},
-		"bad log_format":  {Env: "prod", Addr: ":8080", BaseURL: "x", LogLevel: "info", LogFormat: "yaml", RedisURL: redisOK},
-		"empty addr":      {Env: "prod", Addr: "", BaseURL: "x", LogLevel: "info", LogFormat: "json", RedisURL: redisOK},
-		"empty baseurl":   {Env: "prod", Addr: ":8080", BaseURL: "", LogLevel: "info", LogFormat: "json", RedisURL: redisOK},
-		"empty redis_url": {Env: "prod", Addr: ":8080", BaseURL: "x", LogLevel: "info", LogFormat: "json", RedisURL: ""},
+		"bad env":            {Env: "staging", Addr: ":8080", BaseURL: "x", LogLevel: "info", LogFormat: "json", DatabaseURL: databaseURL, RedisURL: redisURL},
+		"bad log_level":      {Env: "prod", Addr: ":8080", BaseURL: "x", LogLevel: "trace", LogFormat: "json", DatabaseURL: databaseURL, RedisURL: redisURL},
+		"bad log_format":     {Env: "prod", Addr: ":8080", BaseURL: "x", LogLevel: "info", LogFormat: "yaml", DatabaseURL: databaseURL, RedisURL: redisURL},
+		"empty addr":         {Env: "prod", Addr: "", BaseURL: "x", LogLevel: "info", LogFormat: "json", DatabaseURL: databaseURL, RedisURL: redisURL},
+		"empty baseurl":      {Env: "prod", Addr: ":8080", BaseURL: "", LogLevel: "info", LogFormat: "json", DatabaseURL: databaseURL, RedisURL: redisURL},
+		"empty database_url": {Env: "prod", Addr: ":8080", BaseURL: "x", LogLevel: "info", LogFormat: "json", DatabaseURL: "", RedisURL: redisURL},
+		"empty redis_url":    {Env: "prod", Addr: ":8080", BaseURL: "x", LogLevel: "info", LogFormat: "json", DatabaseURL: databaseURL, RedisURL: ""},
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/server/links_integration_test.go
+++ b/internal/server/links_integration_test.go
@@ -64,7 +64,6 @@ func startFullServer(t *testing.T) (string, func()) {
 		BaseURL:    "http://short.test",
 		LogLevel:   "info",
 		LogFormat:  "text",
-		RedisURL:   redisURL,
 		CodeLength: shortener.DefaultLength,
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -248,7 +247,6 @@ func TestServer_GracefulShutdownDrainsBackgroundTasks(t *testing.T) {
 		BaseURL:    "http://short.test",
 		LogLevel:   "info",
 		LogFormat:  "text",
-		RedisURL:   redisURL,
 		CodeLength: shortener.DefaultLength,
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))


### PR DESCRIPTION
Postgres is the system of record for every link; a server booted without a database can only return 500 from every link endpoint. Make that an explicit startup error rather than a logged warning followed by a degraded server.

Changes:

  - config.Validate now rejects an empty database_url with the same shape and rationale as the existing redis_url check.
  - cli.run drops the 'if cfg.DatabaseURL != ""' branch and the accompanying 'running without a database' warn log; the field is guaranteed non-empty by the time the handler executes.
  - config_test gains a dedicated 'empty database_url' rejection case and threads a databaseURL baseline through every other case so failures stay attributable to the mutated field.
  - Existing TestLoad_* tests now set URL_SHORTENER_DATABASE_URL so Load() (which calls Validate()) still returns a config.

The defensive nil-Store branches in server.New are left in place: they're cheap, only reachable through direct library use, and keep the package safe to embed in tests that don't want a real database.