### PR TITLE
feat(server): require Store, Cache, and Generator deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ local `compose.yaml` overrides them for development.
 | `URL_SHORTENER_BASE_URL`       | `http://localhost:8080`       | Public origin used when building short-link URLs.   |
 | `URL_SHORTENER_LOG_LEVEL`      | `info`                        | One of `debug`, `info`, `warn`, `error`.            |
 | `URL_SHORTENER_LOG_FORMAT`     | `text` in dev, `json` in prod | `text` (human-readable) or `json` (structured).     |
-| `URL_SHORTENER_DATABASE_URL`   | _(empty)_                     | Postgres connection string. Redacted when printed.  |
+| `URL_SHORTENER_DATABASE_URL`   | _(empty)_                     | **Required.** Postgres connection string. Redacted when printed. |
 | `URL_SHORTENER_REDIS_URL`      | _(empty)_                     | **Required.** Redis connection string. Redacted when printed.   |
 | `URL_SHORTENER_AUTO_MIGRATE`   | `false`                       | When `true`, `run` applies migrations before serving. Convenient for local dev / single-replica CI; production deployments should leave this off and run `migrate up` as a separate step. |
 | `URL_SHORTENER_CODE_LENGTH`    | `7`                           | Length of auto-generated short codes (base62). Must be in [4, 64]. |
@@ -226,9 +226,11 @@ The HTTP server exposes three operational endpoints:
 | `/readyz`   | Readiness probe                  | Pings every registered dependency. Returns `200` when all are healthy, `503` otherwise.       |
 | `/version`  | Build metadata                   | Returns `{"version":"...","commit":"...","date":"..."}` baked into the binary at build time.  |
 
-`/readyz` checks Postgres (when `URL_SHORTENER_DATABASE_URL` is set) and
-Redis (always required). Each check has its own line in the JSON body so
-operators can see which dependency is unhappy.
+`/readyz` pings Postgres and Redis -- both are mandatory runtime
+dependencies (`config.Validate` rejects an empty
+`URL_SHORTENER_DATABASE_URL` or `URL_SHORTENER_REDIS_URL` at startup).
+Each check has its own line in the JSON body so operators can see
+which dependency is unhappy.
 
 ## Layout (target)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -45,10 +45,12 @@ const (
 	maxRequestBodyBytes = 16 * 1024
 )
 
-// Deps groups the optional runtime dependencies the server needs. Each
-// field may be nil; the server gracefully degrades (e.g. /readyz simply
-// omits checks for missing deps and the links API is not mounted when
-// Store is missing).
+// Deps groups the runtime dependencies the server needs. Every field is
+// required: Postgres is the system of record, Redis is on the redirect
+// hot path, and Generator mints short codes for new links. New panics
+// if any field is nil -- there is no meaningful "degraded" mode for a
+// link shortener that is missing one of them, and silently mounting a
+// half-wired server would only manifest as 500s in production.
 type Deps struct {
 	Store     *store.Store
 	Cache     *cache.Client
@@ -63,16 +65,25 @@ type Server struct {
 	echo   *echo.Echo
 	http   *http.Server
 
-	// links is the constructed handler bundle (or nil when the
-	// caller didn't supply enough deps to mount it). Held on the
-	// server so Serve can drain its background goroutines during
-	// graceful shutdown.
+	// links is the constructed handler bundle. Held on the server
+	// so Serve can drain its background goroutines (async click
+	// counter increments) during graceful shutdown.
 	links *handlers.Links
 }
 
 // New builds a Server with all routes and middleware mounted. It does not
-// start listening; call Run for that.
+// start listening; call Run for that. Panics if any field of deps is nil
+// (see Deps for rationale).
 func New(cfg config.Config, logger *slog.Logger, deps Deps) *Server {
+	switch {
+	case deps.Store == nil:
+		panic("server: Deps.Store must not be nil")
+	case deps.Cache == nil:
+		panic("server: Deps.Cache must not be nil")
+	case deps.Generator == nil:
+		panic("server: Deps.Generator must not be nil")
+	}
+
 	e := echo.New()
 	e.Use(middleware.Recover())
 	e.Use(middleware.RequestID())
@@ -86,45 +97,35 @@ func New(cfg config.Config, logger *slog.Logger, deps Deps) *Server {
 	e.Use(middleware.BodyLimit(maxRequestBodyBytes))
 
 	op := handlers.NewOperational()
-	if deps.Store != nil {
-		op.AddReadinessCheck("postgres", func(ctx context.Context) error {
-			return deps.Store.Pool().Ping(ctx)
-		})
-	}
-	if deps.Cache != nil {
-		op.AddReadinessCheck("redis", deps.Cache.Ping)
-	}
+	op.AddReadinessCheck("postgres", func(ctx context.Context) error {
+		return deps.Store.Pool().Ping(ctx)
+	})
+	op.AddReadinessCheck("redis", deps.Cache.Ping)
 	op.Mount(e)
 
-	// Links API + redirect: requires the full set of deps. Cache is
-	// non-optional -- the handler treats it as always-present (config
-	// validation guarantees URL_SHORTENER_REDIS_URL is set in production).
-	// The HTML web UI (form + recent list) is mounted alongside whenever
-	// the API is up; both reuse the same underlying *handlers.Links.
-	var links *handlers.Links
-	if deps.Store != nil && deps.Cache != nil && deps.Generator != nil {
-		links = handlers.NewLinks(handlers.LinksConfig{
-			Store:     deps.Store,
-			Cache:     deps.Cache,
-			Generator: deps.Generator,
-			BaseURL:   cfg.BaseURL,
-			Logger:    logger,
-		})
-		links.Mount(e)
+	// Links API + redirect, plus the HTML web UI (form + recent list)
+	// mounted alongside; both reuse the same underlying *handlers.Links.
+	links := handlers.NewLinks(handlers.LinksConfig{
+		Store:     deps.Store,
+		Cache:     deps.Cache,
+		Generator: deps.Generator,
+		BaseURL:   cfg.BaseURL,
+		Logger:    logger,
+	})
+	links.Mount(e)
 
-		tmpl, err := web.ParseTemplates()
-		if err != nil {
-			// Templates ship inside the binary, so a parse failure means
-			// a programming error: fail fast at startup.
-			panic(fmt.Errorf("server: parse web templates: %w", err))
-		}
-		webH := handlers.NewWeb(handlers.WebConfig{
-			Links:     links,
-			Templates: tmpl,
-			Logger:    logger,
-		})
-		webH.Mount(e, web.Static())
+	tmpl, err := web.ParseTemplates()
+	if err != nil {
+		// Templates ship inside the binary, so a parse failure means
+		// a programming error: fail fast at startup.
+		panic(fmt.Errorf("server: parse web templates: %w", err))
 	}
+	webH := handlers.NewWeb(handlers.WebConfig{
+		Links:     links,
+		Templates: tmpl,
+		Logger:    logger,
+	})
+	webH.Mount(e, web.Static())
 
 	httpSrv := &http.Server{
 		Addr:              cfg.Addr,
@@ -186,13 +187,10 @@ func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
 	// left in shutdownCtx -- typically most of the 15s, since
 	// http.Shutdown returns as soon as the last in-flight request
 	// finishes -- so the overall stop time is still bounded.
-	if s.links != nil {
-		remaining := timeUntil(shutdownCtx)
-		if remaining > 0 {
-			if !s.links.WaitForBackgroundTasks(remaining) {
-				s.logger.Warn("background tasks did not drain before shutdown deadline",
-					"budget", remaining)
-			}
+	if remaining := timeUntil(shutdownCtx); remaining > 0 {
+		if !s.links.WaitForBackgroundTasks(remaining) {
+			s.logger.Warn("background tasks did not drain before shutdown deadline",
+				"budget", remaining)
 		}
 	}
 

--- a/internal/server/server_integration_test.go
+++ b/internal/server/server_integration_test.go
@@ -12,63 +12,14 @@ package server_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"io"
-	"log/slog"
 	"net"
 	"net/http"
 	"os"
 	"testing"
 	"time"
-
-	"github.com/vancanhuit/url-shortener/internal/config"
-	"github.com/vancanhuit/url-shortener/internal/server"
 )
-
-// startServer spins up a Server bound to 127.0.0.1:0 in a background
-// goroutine. It returns the base URL ("http://127.0.0.1:PORT") and a stop
-// function that cancels the run context and waits for graceful shutdown.
-func startServer(t *testing.T) (string, func()) {
-	t.Helper()
-
-	cfg := config.Config{
-		Env:       config.EnvDev,
-		Addr:      "127.0.0.1:0", // unused by Serve(), but kept for completeness
-		BaseURL:   "http://127.0.0.1",
-		LogLevel:  "info",
-		LogFormat: "text",
-	}
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-
-	srv := server.New(cfg, logger, server.Deps{})
-
-	ctx, cancel := context.WithCancel(t.Context())
-	done := make(chan error, 1)
-	go func() { done <- srv.Serve(ctx, ln) }()
-
-	stop := func() {
-		cancel()
-		select {
-		case err := <-done:
-			if err != nil {
-				t.Errorf("Serve returned error: %v", err)
-			}
-		case <-time.After(20 * time.Second):
-			t.Error("Serve did not return within 20s of cancellation")
-		}
-	}
-
-	// Wait briefly for the listener goroutine to start accepting.
-	waitForReady(t, "http://"+ln.Addr().String()+"/healthz")
-
-	return "http://" + ln.Addr().String(), stop
-}
 
 // waitForReady polls /healthz until it returns 200 or the deadline expires.
 func waitForReady(t *testing.T, url string) {
@@ -109,7 +60,7 @@ func getJSON(t *testing.T, url string) (int, map[string]any) {
 }
 
 func TestServer_OperationalEndpointsOverRealNetwork(t *testing.T) {
-	base, stop := startServer(t)
+	base, stop := startFullServer(t)
 	defer stop()
 
 	t.Run("healthz", func(t *testing.T) {
@@ -123,7 +74,9 @@ func TestServer_OperationalEndpointsOverRealNetwork(t *testing.T) {
 	})
 
 	t.Run("readyz", func(t *testing.T) {
-		// No checks registered -> 200.
+		// Postgres + Redis checks are registered against the real
+		// dependencies wired in startFullServer; both should be
+		// reachable in the test environment, so /readyz returns 200.
 		code, body := getJSON(t, base+"/readyz")
 		if code != http.StatusOK {
 			t.Errorf("status = %d, want 200", code)
@@ -154,7 +107,7 @@ func TestServer_OperationalEndpointsOverRealNetwork(t *testing.T) {
 }
 
 func TestServer_RejectsOversizedRequestBody(t *testing.T) {
-	base, stop := startServer(t)
+	base, stop := startFullServer(t)
 	defer stop()
 
 	// 1 MiB of payload is two orders of magnitude over the 16 KiB cap;
@@ -182,7 +135,7 @@ func TestServer_RejectsOversizedRequestBody(t *testing.T) {
 }
 
 func TestServer_GracefulShutdownClosesListener(t *testing.T) {
-	base, stop := startServer(t)
+	base, stop := startFullServer(t)
 
 	// Verify the server is responsive.
 	if code, _ := getJSON(t, base+"/healthz"); code != http.StatusOK {


### PR DESCRIPTION
Postgres and Redis are both mandatory runtime dependencies (enforced by config.Validate at startup), and Generator is unconditionally constructed in cli.run. Reflect that in server.New: there is no meaningful 'degraded' mode for a link shortener that is missing one of them, and silently mounting a half-wired server only manifests as 500s in production.

Changes:

  - server.New panics with a precise message when any field of Deps is nil. Callers (cli.run, integration tests) already supply all three, so this is a behaviour-preserving guard rail rather than a new failure mode.
  - Drop the 'if deps.Store != nil' / 'if deps.Cache != nil' branches around readiness checks; both probes are always registered. Drop the 'if deps.Store != nil && ...' branch around the links + web mount; both are always wired.
  - Simplify Serve's drain branch: s.links is no longer nilable, so drop the outer nil-guard.
  - Update Deps godoc to document the new contract.
  - server_integration_test.go: delete the local startServer helper that built Deps{} and reuse startFullServer from links_integration_test.go (same package, same env-var skip semantics). The /readyz subtest now verifies the real Postgres + Redis checks return 200 in the test environment.
  - README: mark URL_SHORTENER_DATABASE_URL as **Required** in the env-var table and rewrite the /readyz paragraph to drop the stale 'when DATABASE_URL is set' wording.

Manually verified end-to-end against the test compose stack:

  - GET /healthz  -> 200 {"status":"ok"}
  - GET /readyz   -> 200 {"postgres":"ok","redis":"ok","status":"ok"}
  - GET /readyz with redis paused -> 503
        {"postgres":"ok","redis":"error: context deadline exceeded",
         "status":"unready"}
  - Recovers to 200 once redis is unpaused (no restart needed).