### PR TITLE
ci: add govulncheck job and 'just vuln' recipe

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,6 +89,27 @@ jobs:
       - name: just lint
         run: just lint
 
+  vuln:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      # Vuln scanning works on source, so a shallow checkout is fine
+      # (no `git describe` needed here).
+      - uses: actions/checkout@v6
+      # Reuse the project-wide toolchain composite. govulncheck doesn't
+      # need Node, but the composite always wires it up; the few extra
+      # seconds of setup-node aren't worth a special-case input.
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
+      # `just vuln` self-installs govulncheck@latest into $GOPATH/bin
+      # and runs it with --build-tags=integration so the entire codebase
+      # (including //go:build integration tests) is analysed for
+      # reachable CVEs against the live https://pkg.go.dev/vuln database.
+      - name: just vuln
+        run: just vuln
+
   go-integration:
     name: go (integration)
     runs-on: ubuntu-latest

--- a/Justfile
+++ b/Justfile
@@ -144,7 +144,11 @@ vuln:
     # is already current.
     gobin="$(go env GOPATH)/bin"
     GOBIN="$gobin" go install golang.org/x/vuln/cmd/govulncheck@latest
-    "$gobin/govulncheck" -tags=integration ./...
+    # `-show=verbose` makes the per-run module + package inventory
+    # visible in CI logs, so a failed run is easy to triage and a
+    # passing one documents exactly what was scanned (12 root packages,
+    # ~30 modules, and the stdlib at the time of writing).
+    "$gobin/govulncheck" -show=verbose -tags=integration ./...
 
 # Tidy go.mod / go.sum.
 tidy:

--- a/Justfile
+++ b/Justfile
@@ -127,6 +127,25 @@ lint: lint-install web-build tidy
 fmt: lint-install
     "$(go env GOPATH)/bin/golangci-lint" fmt
 
+# Run govulncheck against the source. govulncheck is the official Go
+# vulnerability scanner: it cross-references our deps against the Go
+# vuln database (https://pkg.go.dev/vuln) AND, crucially, only fails
+# when a known-bad symbol is actually reachable from one of our
+# entrypoints -- so a CVE in a function we never call won't break CI.
+# `--build-tags=integration` matches the lint recipe so files behind
+# the integration build tag are also analysed.
+vuln:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # Always pull the latest CLI: govulncheck's value is the database
+    # it queries, and the CLI itself rarely sees breaking changes worth
+    # pinning. `go install ... @latest` is a fast no-op when the binary
+    # is already current.
+    gobin="$(go env GOPATH)/bin"
+    GOBIN="$gobin" go install golang.org/x/vuln/cmd/govulncheck@latest
+    "$gobin/govulncheck" -tags=integration ./...
+
 # Tidy go.mod / go.sum.
 tidy:
     go mod tidy

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ just build                             # build ./bin/url-shortener (depends on w
 just test                              # run unit tests with -race -v -cover
 just test-integration                  # bring up test-profile infra, migrate, run -tags=integration tests
 just lint                              # run golangci-lint (auto-installs the pinned version)
+just vuln                              # run govulncheck against the latest Go vuln database
 docker compose up --wait -d            # bring up the full local dev stack (db + redis + server on 5432/6379/8080)
 docker compose down -v                 # tear down the dev stack
 docker compose --profile=test down -v  # tear down the test-profile stack (db-test + redis-test on 5433/6380)


### PR DESCRIPTION
govulncheck is the official Go vulnerability scanner. Unlike a plain go.sum scan, it cross-references the Go vuln database (pkg.go.dev/vuln) against your actual call graph -- a CVE in a dependency function we never call won't fail CI. That keeps the false-positive rate near zero while still catching genuinely reachable vulnerabilities the moment the database learns about them.

Changes:

  - Justfile: new 'vuln' recipe. Self-installs golang.org/x/vuln/cmd/ govulncheck@latest (a no-op when already current) and runs it with --build-tags=integration so files behind the integration build tag are analysed alongside the rest. The CLI is intentionally unpinned: the value of govulncheck is the database it queries, fetched fresh each run, and the CLI surface itself rarely changes in ways worth pinning.
  - .github/workflows/ci.yaml: new 'govulncheck' job. Runs in parallel with 'go' / 'go-integration' / 'commitlint', reuses the existing setup-toolchain composite, and shells out to 'just vuln' so local and CI invocations stay identical.
  - README.md: list 'just vuln' alongside the other dev recipes.

Local 'just vuln' currently reports 'No vulnerabilities found.'