### PR TITLE
ci: scan the Docker image with Trivy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,6 +110,35 @@ jobs:
       - name: just vuln
         run: just vuln
 
+  trivy:
+    name: trivy (image scan)
+    runs-on: ubuntu-latest
+    # Don't burn a runner scanning a broken build; gating on `go`
+    # ensures the binary at least compiles before we wrap it in a
+    # container and look for OS-level CVEs.
+    needs: go
+    steps:
+      - uses: actions/checkout@v6
+      # `just trivy-image` calls `just docker-build`, which calls
+      # `just web-build` (npm). The toolchain composite gets us Go +
+      # Node + a primed npm cache, identical to the `go` job.
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
+      # Build the host-arch image and scan it with Trivy. The recipe
+      # installs trivy at the version pinned in the Justfile
+      # (TRIVY_VERSION) into $GOPATH/bin -- the same self-install
+      # pattern used for golangci-lint -- so we avoid the
+      # aquasecurity/trivy-action third-party action that was
+      # compromised in the March-2026 supply-chain incident.
+      #
+      # The recipe gates on HIGH/CRITICAL severities and passes
+      # --ignore-unfixed; bump the gate (or add a TRIVY_SEVERITY
+      # override here) when the policy changes.
+      - name: just trivy-image
+        run: just trivy-image
+
   go-integration:
     name: go (integration)
     runs-on: ubuntu-latest

--- a/Justfile
+++ b/Justfile
@@ -23,6 +23,11 @@ PLATFORMS              := "linux/amd64,linux/arm64"
 # env var defined in .github/workflows/ci.yaml so there is a single source of
 # truth per run; the literal here is the default for local development.
 GOLANGCI_LINT_VERSION  := env("GOLANGCI_LINT_VERSION", "2.11.4")
+# Trivy version. Installed via the official install.sh into $GOPATH/bin
+# rather than the aquasecurity/trivy-action GitHub Action -- the action
+# was compromised in the March-2026 supply-chain incident, so we stick
+# to the upstream binary at a pinned version we control.
+TRIVY_VERSION          := env("TRIVY_VERSION", "0.70.0")
 LDFLAGS := "-s -w" + \
     " -X github.com/vancanhuit/url-shortener/internal/buildinfo.version=" + VERSION + \
     " -X github.com/vancanhuit/url-shortener/internal/buildinfo.commit="  + COMMIT  + \
@@ -149,6 +154,44 @@ vuln:
     # passing one documents exactly what was scanned (12 root packages,
     # ~30 modules, and the stdlib at the time of writing).
     "$gobin/govulncheck" -show=verbose -tags=integration ./...
+
+# Install trivy v{{TRIVY_VERSION}} into $GOPATH/bin via the official
+# install.sh. Idempotent: a no-op when the right version is already
+# present. We pin to a specific release rather than tracking `latest`
+# because trivy is a security-critical binary; reproducible scans
+# require a reproducible scanner, and bumps should be intentional.
+trivy-install:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    gobin="$(go env GOPATH)/bin"
+    bin="$gobin/trivy"
+    want="{{TRIVY_VERSION}}"
+    have="$([ -x "$bin" ] && "$bin" --version 2>/dev/null | awk '/^Version/ {print $2}' | head -1 || echo none)"
+    if [ "$have" = "$want" ]; then
+        echo "trivy $want already installed at $bin"
+    else
+        echo "installing trivy $want into $gobin (have: $have)"
+        curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
+            | sh -s -- -b "$gobin" "v$want"
+    fi
+
+# Build the local Docker image (`url-shortener:dev`) and scan it with
+# Trivy. Complements `just vuln`: govulncheck only sees Go code, while
+# Trivy inspects the entire runtime image -- the distroless base, the
+# embedded binary, and any OS-level CPEs the registry knows about.
+#
+# Severity gate: HIGH and CRITICAL fail the run; --ignore-unfixed
+# silences findings for which there is no upstream fix yet (we cannot
+# act on those, and they otherwise create perpetual noise). Tune this
+# in CI by overriding TRIVY_SEVERITY when the policy needs to change.
+trivy-image: trivy-install docker-build
+    "$(go env GOPATH)/bin/trivy" image \
+        --severity HIGH,CRITICAL \
+        --ignore-unfixed \
+        --exit-code 1 \
+        --no-progress \
+        url-shortener:dev
 
 # Tidy go.mod / go.sum.
 tidy:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ just test                              # run unit tests with -race -v -cover
 just test-integration                  # bring up test-profile infra, migrate, run -tags=integration tests
 just lint                              # run golangci-lint (auto-installs the pinned version)
 just vuln                              # run govulncheck against the latest Go vuln database
+just trivy-image                       # build the Docker image and scan it with Trivy (HIGH/CRITICAL)
 docker compose up --wait -d            # bring up the full local dev stack (db + redis + server on 5432/6379/8080)
 docker compose down -v                 # tear down the dev stack
 docker compose --profile=test down -v  # tear down the test-profile stack (db-test + redis-test on 5433/6380)


### PR DESCRIPTION
Add a Trivy image-scanning job to CI plus a 'just trivy-image' recipe for local parity. Trivy complements the existing 'vuln' job (govulncheck): govulncheck only sees Go code paths, while Trivy inspects the entire runtime image -- distroless base layer, embedded binary, and any OS-level CPEs the registry knows about.

Justfile:

  - TRIVY_VERSION pinned at 0.70.0 (env-overridable). Pinning the scanner is important: reproducible findings require a reproducible scanner, and version bumps should be intentional.
  - 'trivy-install' self-installs the binary into $GOPATH/bin via the official aquasecurity/trivy install.sh -- idempotent, no-op when the right version is already present. Mirrors the 'lint-install' / 'golangci-lint' pattern.
  - 'trivy-image' depends on 'trivy-install' + 'docker-build' and scans the resulting 'url-shortener:dev' image. Severity gate is HIGH,CRITICAL with --ignore-unfixed (silences findings we cannot act on; otherwise they accumulate as perpetual noise).

CI (.github/workflows/ci.yaml):

  - New 'trivy' job, runs in parallel with 'vuln' / 'image' / 'go-integration' once the 'go' job confirms the binary builds. Reuses the setup-toolchain composite for cache locality and shells out to 'just trivy-image' so local and CI invocations stay identical.
  - Deliberately NOT using aquasecurity/trivy-action: that action was compromised in the March-2026 supply-chain incident (https://github.com/aquasecurity/trivy/discussions/10425\), so we install the upstream binary at a version we control instead of running third-party action code on every build.

README: lists 'just trivy-image' alongside the other dev recipes.