### PR TITLE
ci: attach SBOM + SLSA provenance to all published images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -326,6 +326,16 @@ jobs:
             VERSION=${{ steps.meta-build.outputs.version }}
             COMMIT=${{ github.sha }}
             DATE=${{ steps.meta-build.outputs.date }}
+          # Attach an SPDX SBOM (sbom: true; BuildKit's default scanner
+          # emits SPDX 2.3) and SLSA-style provenance in `max` mode (full
+          # source/build-step graph) as in-toto attestations on the
+          # manifest index. Consumers fetch them with
+          # `docker buildx imagetools inspect ghcr.io/.../url-shortener:edge
+          # --format '{{ json .SBOM }}'` (or .Provenance), and downstream
+          # tools like `trivy sbom` / `cosign verify-attestation` can
+          # consume them directly without rebuilding.
+          sbom: true
+          provenance: mode=max
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -347,6 +357,11 @@ jobs:
             VERSION=${{ steps.meta-build.outputs.version }}
             COMMIT=${{ github.sha }}
             DATE=${{ steps.meta-build.outputs.date }}
+          # Mirror the main-only build so reviewers downloading the OCI
+          # tarball get a complete artifact: the SBOM + provenance are
+          # written into the same tarball next to the image manifests.
+          sbom: true
+          provenance: mode=max
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -138,6 +138,16 @@ jobs:
             VERSION=${{ steps.meta-build.outputs.version }}
             COMMIT=${{ github.sha }}
             DATE=${{ steps.meta-build.outputs.date }}
+          # Attach an SPDX SBOM (BuildKit's default scanner emits SPDX 2.3)
+          # and SLSA-style provenance in `max` mode (full source/build-step
+          # graph) as in-toto attestations on the manifest index.
+          # Released images are the ones consumers actually deploy from,
+          # so these matter most here -- a downstream user can always
+          # answer "what's in v1.2.3?" with one `docker buildx imagetools
+          # inspect` call instead of rebuilding from source. See ci.yaml's
+          # image job for the consumer-side fetch commands.
+          sbom: true
+          provenance: mode=max
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Justfile
+++ b/Justfile
@@ -327,12 +327,21 @@ release-binaries V=VERSION: web-build
 # Multi-arch build for linux/amd64 + linux/arm64. By default loads nothing
 # (buildx cannot --load multi-arch into the local daemon); pass `true`
 # as the first argument to publish to a registry.
+#
+# `--sbom=true` and `--provenance=mode=max` mirror the CI build-push-action
+# settings so a local multi-arch build produces the same in-toto
+# attestations the registry-pushed image carries. Local single-arch
+# `docker-build` skips them: BuildKit can only attach attestations to
+# images with the OCI v1.1 manifest layout, which the local docker daemon
+# (used by `--load`) does not accept.
 docker-buildx PUSH="false":
     docker buildx build \
         --platform {{PLATFORMS}} \
         --build-arg VERSION={{VERSION}} \
         --build-arg COMMIT={{COMMIT}} \
         --build-arg DATE={{DATE}} \
+        --sbom=true \
+        --provenance=mode=max \
         -t url-shortener:{{VERSION}} \
         {{ if PUSH == "true" { "--push" } else { "--output=type=image,push=false" } }} \
         .

--- a/README.md
+++ b/README.md
@@ -313,6 +313,35 @@ The binary embeds a `git describe` version string of the form
 so `url-shortener version` always identifies which commit produced
 a given build, regardless of where it came from.
 
+### Image attestations (SBOM + provenance)
+
+Every image published to GHCR &mdash; tagged releases, the `:edge`
+floating tag, and the per-commit `:main-<sha>` tags &mdash; ships
+with two in-toto attestations stored next to the manifest:
+
+- An **SPDX SBOM** listing every Go module, npm package, and
+  OS-level component baked into the runtime image. Useful for
+  answering "are we shipping &lt;vulnerable-dep&gt;?" without
+  rebuilding from source.
+- A **SLSA-style provenance** attestation in `max` mode that pins
+  the image digest to the workflow run, the source repo, and the
+  commit SHA that produced it.
+
+Fetch them with `docker buildx`:
+
+```sh
+docker buildx imagetools inspect ghcr.io/vancanhuit/url-shortener:v1.2.3 \
+    --format '{{ json .SBOM }}'        # or .Provenance
+
+# Pipe the SBOM straight to a vulnerability scanner:
+docker buildx imagetools inspect ghcr.io/vancanhuit/url-shortener:v1.2.3 \
+    --format '{{ json .SBOM.SPDX }}' | trivy sbom -
+```
+
+Pull-request OCI tarballs (`oci-image-pr-<N>`) carry the same
+attestations, so reviewers can run the same commands against a
+loaded image.
+
 ## License
 
 To be added.


### PR DESCRIPTION
Turn on BuildKit's in-toto attestation outputs across every `docker/build-push-action` call. Each image -- tagged release, `:edge`, `:main-<sha>`, and the PR OCI tarballs -- now ships with two attestations stored next to the manifest:

  - `sbom: true`           -> SPDX 2.3 SBOM listing every Go module,
                             npm package, and OS-level component
                             baked into the runtime image. BuildKit's
                             default scanner emits SPDX; we accept
                             that default rather than wiring in a
                             CycloneDX scanner image (one less moving
                             part).
  - `provenance: mode=max` -> full SLSA-style provenance pinning the
                             image digest to the workflow run, source
                             repo, and commit SHA that produced it.
                             `mode=max` (vs the default `min`) adds
                             the source/build-step graph, which is
                             what consumers actually want when
                             auditing a binary they pulled.

Files touched:

  - `.github/workflows/ci.yaml`: both `build-push-action` calls in the `image` job (main-only push + PR OCI tarball) get `sbom` + max provenance, with a comment block pointing at the consumer-side `docker buildx imagetools inspect` command.
  - `.github/workflows/release.yaml`: the release-image `build-push-action` call gets the same flags. These are the images consumers deploy from, so attestations matter most here.
  - `Justfile`: `docker-buildx` (multi-arch) recipe gains `--sbom=true --provenance=mode=max` so a local multi-arch build matches CI. `docker-build` (single-arch `--load`) intentionally stays as-is: BuildKit can only attach attestations to OCI v1.1 manifests, which the local docker daemon does not accept.
  - `README.md`: new 'Image attestations' section under Releases with the `docker buildx imagetools inspect` fetch command and a one-liner that pipes the SBOM straight into `trivy sbom -` for ad-hoc scanning of a deployed image.

No new tools, no new jobs, no new secrets. The attestations live in the same registry as the image and are fetched by digest, so this also costs nothing in storage on the consumer side.