### PR TITLE
ci: nightly trivy re-scan of published images

### DIFF
--- a/.github/workflows/nightly-scan.yaml
+++ b/.github/workflows/nightly-scan.yaml
@@ -1,0 +1,107 @@
+# Nightly vulnerability re-scan of the published images.
+#
+# A passing `image` job in ci.yaml only proves the image was clean
+# *at build time*. CVEs disclosed afterwards can land against
+# components we already shipped (a fresh log4shell-style 0-day in a
+# pgx dep, a glibc CVE backported into the distroless base, etc.) --
+# the build is reproducible, the world is not.
+#
+# This workflow re-pulls the floating tags every morning and runs
+# `trivy image` against them. A red run means a CVE has appeared
+# against an image that's currently the recommended pull target;
+# fix it by bumping the offending dep on `main` and letting the
+# `image` job in ci.yaml republish `:edge`, then cut a release for
+# `:latest`.
+#
+# Why floating tags only:
+#   - `:edge` always exists once we've pushed to main; tracks dev.
+#   - `:latest` exists once a stable release ships; tracks prod.
+#   - Pinned tags (`:v1.2.3`, `:main-<sha>`) are immutable artefacts.
+#     A consumer pinned to one is responsible for their own scanning;
+#     re-scanning every historical tag from this side would just be
+#     noise here.
+name: nightly scan
+
+on:
+  # 22:30 UTC == 05:30 ICT (Asia/Ho_Chi_Minh, no DST). Picks an
+  # early-morning local hour so a failing scan is sitting in the
+  # inbox at the start of the working day, and avoids the
+  # top-of-hour stampede that GitHub-hosted schedulers hit daily.
+  # GitHub Actions cron is UTC-only -- no TZ field is supported.
+  schedule:
+    - cron: "30 22 * * *"
+  # Manual trigger for ad-hoc runs after a CVE disclosure or when
+  # validating a fix landed.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+# Don't stack runs: if a scan is already going (long-running CVE DB
+# fetch, slow runner) and another fires, drop the duplicate.
+concurrency:
+  group: nightly-scan
+  cancel-in-progress: false
+
+env:
+  GO_VERSION: 1.26.2
+  NODE_VERSION: 24.14.1
+  REGISTRY: ghcr.io
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  scan:
+    name: trivy ${{ matrix.tag }}
+    runs-on: ubuntu-latest
+    strategy:
+      # `fail-fast: false` so a CVE in `:edge` doesn't cancel the
+      # `:latest` scan -- we want both verdicts every run, not the
+      # first failure.
+      fail-fast: false
+      matrix:
+        tag: [edge, latest]
+    steps:
+      - uses: actions/checkout@v6
+      # `just trivy-scan-image` self-installs trivy at the version
+      # pinned in the Justfile; the toolchain composite gives us Go
+      # so `$(go env GOPATH)/bin` resolves correctly.
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
+
+      # GHCR allows anonymous pulls for public packages, but logging
+      # in costs nothing and keeps the workflow working if the
+      # package visibility is ever flipped to private.
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # `:latest` only exists once a stable release ships; before
+      # the first tag, scanning it would always fail. Probe the
+      # registry first and skip the scan with a workflow notice
+      # rather than red-X'ing every nightly run until v1.0.0.
+      - name: Probe tag existence
+        id: probe
+        run: |
+          ref="${{ env.REGISTRY }}/${{ github.repository }}:${{ matrix.tag }}"
+          if docker manifest inspect "$ref" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::scanning $ref"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::$ref does not exist yet, skipping"
+          fi
+
+      # Same recipe `just trivy-image` uses, just pointed at a
+      # registry ref instead of the local-build tag. HIGH/CRITICAL
+      # gate, --ignore-unfixed, exit-code=1 on findings -- a red
+      # run is the alarm.
+      - name: just trivy-scan-image
+        if: steps.probe.outputs.exists == 'true'
+        run: |
+          just trivy-scan-image '${{ env.REGISTRY }}/${{ github.repository }}:${{ matrix.tag }}'

--- a/Justfile
+++ b/Justfile
@@ -176,22 +176,28 @@ trivy-install:
             | sh -s -- -b "$gobin" "v$want"
     fi
 
-# Build the local Docker image (`url-shortener:dev`) and scan it with
-# Trivy. Complements `just vuln`: govulncheck only sees Go code, while
-# Trivy inspects the entire runtime image -- the distroless base, the
-# embedded binary, and any OS-level CPEs the registry knows about.
+# Scan an arbitrary image reference (registry tag, digest, or local
+# daemon image) with Trivy. Used by both the local `trivy-image`
+# recipe (which builds first) and the nightly-scan workflow (which
+# scans the already-published GHCR image).
 #
 # Severity gate: HIGH and CRITICAL fail the run; --ignore-unfixed
 # silences findings for which there is no upstream fix yet (we cannot
-# act on those, and they otherwise create perpetual noise). Tune this
-# in CI by overriding TRIVY_SEVERITY when the policy needs to change.
-trivy-image: trivy-install docker-build
+# act on those, and they otherwise create perpetual noise).
+trivy-scan-image IMAGE: trivy-install
     "$(go env GOPATH)/bin/trivy" image \
         --severity HIGH,CRITICAL \
         --ignore-unfixed \
         --exit-code 1 \
         --no-progress \
-        url-shortener:dev
+        {{IMAGE}}
+
+# Build the local Docker image (`url-shortener:dev`) and scan it with
+# Trivy. Complements `just vuln`: govulncheck only sees Go code, while
+# Trivy inspects the entire runtime image -- the distroless base, the
+# embedded binary, and any OS-level CPEs the registry knows about.
+trivy-image: docker-build
+    just trivy-scan-image url-shortener:dev
 
 # Tidy go.mod / go.sum.
 tidy:


### PR DESCRIPTION
A passing `image` job in `ci.yaml` only proves the image was clean *at build time*. CVEs disclosed afterwards land against components we already shipped (a fresh log4shell-class issue in a transitive Go dep, a glibc CVE backported into the distroless base, etc.) -- the build is reproducible, the world is not. This workflow closes that gap by re-scanning the floating tags every morning.

`.github/workflows/nightly-scan.yaml`:

  - Schedule: `30 22 * * *` UTC (== 05:30 ICT, Asia/Ho_Chi_Minh, no DST). Off-peak both sides of the dateline and lands a failing run in the inbox before the working day starts. GitHub Actions `cron` is UTC-only -- no TZ field exists -- so the comment block records the local equivalent.
  - Also `workflow_dispatch` for ad-hoc runs after a CVE disclosure or when validating a fix.
  - Matrix over `[edge, latest]`: the floating tags consumers actually pull. Pinned tags (`:v1.2.3`, `:main-<sha>`) are immutable artefacts -- a consumer pinned to one is responsible for their own scanning, re-scanning them here would just be noise.
  - `fail-fast: false` so a CVE in `:edge` doesn't cancel the `:latest` scan; we want both verdicts every run.
  - Probes `docker manifest inspect` first and skips with a workflow notice when a tag is missing, so this stays green until `:latest` exists (i.e. until v1.0.0 ships).
  - Uses `just trivy-scan-image`; same Justfile-pinned trivy version as the per-PR `trivy` job, no third-party action.

`Justfile`:

  - New `trivy-scan-image IMAGE` recipe that takes any image ref (registry tag, digest, or local daemon image) -- no build step, just install + scan. Same `HIGH,CRITICAL` / `--ignore-unfixed` / `--exit-code 1` policy as before.
  - `trivy-image` now delegates to `trivy-scan-image` after `docker-build`, so the local-build path and the registry-scan path share a single trivy invocation -- no policy drift between local and CI.