### PR TITLE
chore(web): use `cp` and `mkdir` in npm scripts

### DIFF
--- a/web/tailwind/package.json
+++ b/web/tailwind/package.json
@@ -3,11 +3,11 @@
   "private": true,
   "description": "Tailwind v4 + HTMX 2 toolchain for the url-shortener web UI.",
   "scripts": {
-    "ensure:dir": "node -e \"require('fs').mkdirSync('../static',{recursive:true})\"",
+    "ensure:dir": "mkdir -p ../static",
     "build:css": "tailwindcss -i ./input.css -o ../static/styles.css --minify",
     "watch:css": "tailwindcss -i ./input.css -o ../static/styles.css --watch",
-    "vendor:htmx": "node -e \"require('fs').copyFileSync('node_modules/htmx.org/dist/htmx.min.js','../static/htmx.min.js')\"",
-    "vendor:copy": "node -e \"require('fs').copyFileSync('copy.js','../static/copy.js')\"",
+    "vendor:htmx": "cp node_modules/htmx.org/dist/htmx.min.js ../static/htmx.min.js",
+    "vendor:copy": "cp copy.js ../static/copy.js",
     "build": "npm run ensure:dir && npm run build:css && npm run vendor:htmx && npm run vendor:copy"
   },
   "devDependencies": {


### PR DESCRIPTION
Replace the `node -e "require('fs').(copyFileSync|mkdirSync)(...)"` incantations in `web/tailwind/package.json` with plain `cp` and `mkdir -p`. The Node-eval form was a portability hedge for Windows (`cp` is POSIX-only), but the rest of the toolchain already assumes a Unix host:

  - the `Justfile` is bash-only (heredocs, `set -euo pipefail`, `go env GOPATH`),
  - the `Dockerfile` builds in a Linux container,
  - CI runs on `ubuntu-latest`.

Realistic contributor matrix is WSL + macOS, both of which have `cp` and `mkdir`. The Windows-native case isn't supported anywhere else, so paying readability for it here was a tax with no payoff.

Verified end-to-end with `just web-build`: `web/static/` ends up with `styles.css`, `htmx.min.js`, and `copy.js` exactly as before.