### PR TITLE
ci: add CodeQL static analysis

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -71,7 +71,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@14c9a0cbe6373488c2a41f7e75c8dd142bb2aba8 # v3.35.3
+        uses: github/codeql-action/init@c3f298df8c1fea2fefe20c785e6aa00f32df8260 # v4.35.3
         with:
           languages: ${{ matrix.language }}
           # `security-extended` adds higher-precision queries beyond
@@ -91,9 +91,9 @@ jobs:
         run: just web-build
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@14c9a0cbe6373488c2a41f7e75c8dd142bb2aba8 # v3.35.3
+        uses: github/codeql-action/autobuild@c3f298df8c1fea2fefe20c785e6aa00f32df8260 # v4.35.3
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@14c9a0cbe6373488c2a41f7e75c8dd142bb2aba8 # v3.35.3
+        uses: github/codeql-action/analyze@c3f298df8c1fea2fefe20c785e6aa00f32df8260 # v4.35.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,99 @@
+name: codeql
+
+# CodeQL static analysis. Catches a different class of bugs than
+# `golangci-lint` + `govulncheck` -- specifically taint-tracking and
+# injection sinks (path traversal, SSRF, SQL via fmt.Sprintf, unsafe
+# template usage, etc.) that pattern-based linters miss.
+#
+# Findings appear in the repo's Security -> Code scanning tab.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    # Re-scan weekly so the database catches up with new query
+    # versions GitHub publishes between PRs. Monday 03:17 UTC -- a
+    # quiet slot, offset off-the-hour to avoid the schedule-storm
+    # that hits other workflows pinned to :00.
+    - cron: "17 3 * * 1"
+
+# Default to read-only; the analyze job opts into security-events
+# write so the SARIF upload can post results to the Security tab.
+permissions:
+  contents: read
+
+# Stack PR runs the same way ci.yaml does so a rapid push series
+# only spends one runner-pair on analysis.
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  # Toolchain versions kept in lockstep with ci.yaml. Bump there
+  # first; this workflow re-asserts the literals so a CodeQL run
+  # cannot silently fall behind production CI on a Go bump.
+  GO_VERSION: 1.26.2
+  NODE_VERSION: 24.14.1
+  # See ci.yaml for the rationale on the Node-24 opt-in flag.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  analyze:
+    name: analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # SARIF upload to the Security tab.
+      security-events: write
+      # Read workflow run metadata (used by the action for cache keys
+      # and to attribute findings to the right run).
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # Only Go for now; the vendored client-side JS (theme.js,
+        # copy.js) is trivial and adding the javascript-typescript
+        # language would scan node_modules and slow the run for
+        # near-zero signal. Revisit if the client code grows.
+        language: [go]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Same Go + Node + just toolchain the rest of CI uses, so the
+      # CodeQL autobuild step compiles against the same versions
+      # production builds compile against. Sharing the composite
+      # also means there's exactly one place to fix when toolchain
+      # setup changes.
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@14c9a0cbe6373488c2a41f7e75c8dd142bb2aba8 # v3.35.3
+        with:
+          languages: ${{ matrix.language }}
+          # `security-extended` adds higher-precision queries beyond
+          # the default suite (SSRF, command injection, weak crypto).
+          # Skip `security-and-quality` -- the `quality` queries
+          # overlap heavily with golangci-lint and produce noise.
+          queries: security-extended
+
+      # Build the real Tailwind + htmx bundle into web/static/ so the
+      # `//go:embed static` directive in web/web.go finds the same
+      # assets it would in production. CodeQL only inspects Go AST
+      # + types, so the asset *contents* don't change analysis
+      # results -- but using the same build path as ci.yaml /
+      # release.yaml keeps the workflows mentally uniform and
+      # surfaces any embed-time regressions here too.
+      - name: just web-build
+        run: just web-build
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@14c9a0cbe6373488c2a41f7e75c8dd142bb2aba8 # v3.35.3
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@14c9a0cbe6373488c2a41f7e75c8dd142bb2aba8 # v3.35.3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
GitHub-hosted CodeQL run that complements the existing `golangci-lint` + `govulncheck` pass. CodeQL's value here is taint-tracking and injection-sink analysis (path traversal, SSRF, SQL via raw `fmt.Sprintf`, unsafe `html/template` usage, command injection, weak crypto primitives) -- a different bug class from the pattern-based + known-vulnerability tooling already in CI.

Findings land in the repo's Security -> Code scanning tab and on PR diffs as inline review comments.

Triggers
========

  - Pull requests targeting main: gate-keeps regressions before merge.
  - Pushes to main: catches anything that lands via direct push or that the PR run missed (e.g., merge-time interactions).
  - Weekly schedule (Mon 03:17 UTC): re-runs against the current query packs so newly-published queries get applied to the existing codebase without waiting for the next PR.

Configuration choices
=====================

  - language: go only. The vendored client-side JS (theme.js, copy.js) is trivial and pulling in the `javascript-typescript` language would scan node_modules for little signal -- can revisit if the client code grows.

  - queries: security-extended. Adds higher-precision security queries beyond the default suite. Deliberately skips `security-and-quality`: the `quality` queries overlap heavily with golangci-lint output and produce noise without finding bugs the linter missed.

  - Pinned commit SHAs (`14c9a0c...` for codeql-action v3.35.3) matching the repo-wide policy on third-party action pinning.

Build path
==========

Uses the same `./.github/actions/setup-toolchain` composite + `just web-build` recipe that ci.yaml / release.yaml / nightly-scan.yaml use, so the CodeQL autobuild step compiles against the exact same Go + Tailwind + htmx output production builds use. Costs ~45s of npm + Tailwind compile per run vs. stubbing empty embed assets, but keeps "one build path everywhere" as an invariant -- worth the runtime for the maintenance simplification.

Permissions
===========

Workflow defaults to `contents: read`. The analyze job opts into `security-events: write` (SARIF upload to the Security tab) and `actions: read` (run-metadata lookup for caching). No write scope to anything else.