### PR TITLE
ci: enable step-security/harden-runner in audit mode

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,15 @@ jobs:
     # commits, and the squash-merge produces a fresh conventional commit.
     if: github.event_name == 'pull_request'
     steps:
+      # Audit-only runtime monitoring (step-security/harden-runner):
+      # logs every outbound connection, file write, and process spawn
+      # this job makes. Does NOT block in audit mode -- after a week
+      # or two of data via the job summary, flip `egress-policy` to
+      # `block` with a curated `allowed-endpoints` list. Repeated as
+      # the first step of every job below; see this comment for why.
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # commitlint runs `just init`, which `npm ci`s the root toolchain
       # (husky + @commitlint/*). Point the npm cache at the root lockfile
@@ -67,6 +76,9 @@ jobs:
     name: go (build / test / lint)
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       # fetch-depth: 0 so `just build` -> `git describe` can resolve the
       # version string against the most recent tag, producing meaningful
       # `v1.2.3-N-gSHA` ldflags on PR/main builds instead of the bare SHA.
@@ -95,6 +107,9 @@ jobs:
     name: govulncheck
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       # Vuln scanning works on source, so a shallow checkout is fine
       # (no `git describe` needed here).
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -120,6 +135,9 @@ jobs:
     # container and look for OS-level CVEs.
     needs: go
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # `just trivy-image` calls `just docker-build` (the Dockerfile's
       # own builder stages handle Go + npm) and `just trivy-scan`
@@ -144,6 +162,9 @@ jobs:
     name: go (integration)
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       # Same fetch-depth: 0 reasoning as the `go` job above.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -183,6 +204,9 @@ jobs:
     needs: go
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       # fetch-depth: 0 so the version baked into each binary reflects
       # the distance from the most recent tag (e.g. `v1.2.3-5-gabcdef0`).
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -240,6 +264,9 @@ jobs:
       contents: read
       packages: write
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       # fetch-depth: 0 so the version build-arg picked up below reflects
       # the distance from the most recent tag (e.g. `v1.2.3-5-gabcdef0`),
       # not just the bare commit SHA.

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -58,6 +58,15 @@ jobs:
         # near-zero signal. Revisit if the client code grows.
         language: [go]
     steps:
+      # Audit-only runtime monitoring (step-security/harden-runner):
+      # logs every outbound connection, file write, and process spawn
+      # this job makes. Does NOT block in audit mode -- after a week
+      # or two of data via the job summary, flip `egress-policy` to
+      # `block` with a curated `allowed-endpoints` list. Repeated as
+      # the first step of every job below; see this comment for why.
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Same Go + Node + just toolchain the rest of CI uses, so the

--- a/.github/workflows/nightly-scan.yaml
+++ b/.github/workflows/nightly-scan.yaml
@@ -64,6 +64,15 @@ jobs:
       matrix:
         tag: [edge, latest]
     steps:
+      # Audit-only runtime monitoring (step-security/harden-runner):
+      # logs every outbound connection, file write, and process spawn
+      # this job makes. Does NOT block in audit mode -- after a week
+      # or two of data via the job summary, flip `egress-policy` to
+      # `block` with a curated `allowed-endpoints` list. Repeated as
+      # the first step of every job below; see this comment for why.
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # `just trivy-scan` self-installs trivy at the version pinned
       # in the Justfile (TRIVY_VERSION) into $HOME/.local/bin via

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,6 +58,15 @@ jobs:
       contents: read
       packages: write
     steps:
+      # Audit-only runtime monitoring (step-security/harden-runner):
+      # logs every outbound connection, file write, and process spawn
+      # this job makes. Does NOT block in audit mode -- after a week
+      # or two of data via the job summary, flip `egress-policy` to
+      # `block` with a curated `allowed-endpoints` list. Repeated as
+      # the first step of every job below; see this comment for why.
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
@@ -158,6 +167,9 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0


### PR DESCRIPTION
Add `step-security/harden-runner@v2.19.0` (SHA-pinned to `8d3c67de8e2fe68ef647c8db1e6a09f647780f40`) as the first step of every job in every workflow (`ci.yaml`, `release.yaml`, `nightly-scan.yaml`, `codeql.yaml`). Configured in `audit` mode -- it observes and logs but does not block.

Why this layer
==============

SHA-pinning (#57) freezes *which* third-party action code we run. Least-privilege `permissions:` blocks bound *what tokens* a compromised job can wield. Neither stops a runtime exfil from a transitive npm/Go dep that was already malicious at the SHA we pinned -- the `tj-actions/changed-files` (March 2025) and `codecov-bash` (April 2021) class of attack. harden-runner watches the runner kernel-side (eBPF + iptables) so unexpected outbound connections, file writes, and child processes are visible in the job summary -- and, once we promote to `block`, dropped at the network layer.

Two-step rollout
================

This commit is step 1 of 2:

  1. (this PR) `egress-policy: audit` -- non-blocking. Every job run produces a "Discovered Endpoints" + "Outbound calls" section in its job summary listing the domains that step touched. Runs for ~1-2 weeks.
  2. (follow-up) `egress-policy: block` with a curated `allowed-endpoints:` list derived from the audit data. From that point unexpected egress fails the job.

Skipping step 1 is how you lock yourself out: `proxy.golang.org`, `sum.golang.org`, `objects.githubusercontent.com`, `registry.npmjs.org`, `ghcr.io`, etc. all need explicit allowlist entries and the exact set varies per job (the `commitlint` job hits a different surface than `image`).

Layout
======

The first job of each workflow file gets a six-line explanatory comment block; subsequent jobs get the bare three-line `uses:` / `with:` invocation pointing back to that comment. Keeps the diff readable without duplicating the rationale 11 times.

Composite actions (`./.github/actions/setup-toolchain`, `./.github/actions/resolve-build-metadata`) are intentionally not hardened -- they're not jobs, they run inside a job whose first step already installed harden-runner, so the monitor is already active by the time they execute.