### PR TITLE
ci: surface buildx cache layout per run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -401,3 +401,17 @@ jobs:
           path: ./url-shortener-oci.tar
           if-no-files-found: error
           retention-days: 7
+
+      # Diagnostic: surface the buildx cache layout in the job log so
+      # cache hit-rate is auditable without scraping per-step output.
+      # `build-push-action` already writes a per-stage hit/miss table
+      # to $GITHUB_STEP_SUMMARY (its `summary: true` default); this
+      # step adds a complementary view of which layers are actually
+      # resident in the GHA cache after the build. `if: always()` so
+      # it runs after either the main-push or PR-tarball branch above;
+      # `continue-on-error` keeps a future buildx CLI change from
+      # failing the workflow over a diagnostic.
+      - name: buildx cache stats
+        if: always()
+        continue-on-error: true
+        run: docker buildx du

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -160,6 +160,13 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # See ci.yaml's image job for the rationale behind this step.
+      # Diagnostic only; never fails the workflow.
+      - name: buildx cache stats
+        if: always()
+        continue-on-error: true
+        run: docker buildx du
+
   release:
     name: github release
     needs: image


### PR DESCRIPTION
Add a `docker buildx du` diagnostic step after each `docker/build-push-action` invocation in `ci.yaml` (image job, covering both the main-push and PR-tarball branches via a single trailing step) and `release.yaml` (image job).

What this gives us
==================

`build-push-action` already writes a per-stage hit/miss table to `$GITHUB_STEP_SUMMARY` via its default `summary: true`. That tells us *which stages were cached during this build*. The new step is the complementary view: *which layers are actually resident in the GHA cache after the build*, with sizes and last-used timestamps.

Together they make cache health auditable per run without scraping individual step logs.

Why nothing else changed
========================

Pulled the recent CI run logs via `gh run view` to verify cache behaviour before touching anything:

  - `docker image` job (ci.yaml main-push, run #25253524253): `importing cache manifest from gha:11894249595678861107` plus 7 layers reported as `CACHED`. Wall time 2m06s. The cache is already working as intended.

  - `trivy (image scan)` job: ran `npm ci`, `npm run build`, and `go build` cold (no `CACHED` markers anywhere). But the build portion is only ~38s of a 1m10s job, and trivy runs in parallel with the longer `docker image` (2m06s) job that gates pipeline duration. Refactoring trivy onto buildx + GHA cache would save ~30s of CI compute per run but zero wall-clock improvement.

So: no scope rename (default `scope=buildkit` is functioning), no trivy refactor (savings don't justify the diff), just the diagnostic step.

Verification after merge
========================

Open any image-job run -> bottom of the log:

  - "buildx cache stats" step output: `docker buildx du` table.
  - "Job summary" panel: build-push-action's per-stage cache table.

`if: always()` so the step runs whether the build succeeded or failed; `continue-on-error: true` so a future buildx CLI change can never fail the workflow over a diagnostic.