### PR TITLE
test(server): assert /readyz flips to 503 on dependency outage

### DIFF
--- a/internal/server/links_integration_test.go
+++ b/internal/server/links_integration_test.go
@@ -28,7 +28,26 @@ import (
 // startFullServer spins up a Server with a real Postgres, Redis, and code
 // generator. It skips the test when the URL_SHORTENER_TEST_* env vars are
 // unset (matching the behavior of the per-package integration tests).
+//
+// Most callers only need the base URL + stop func; tests that need to
+// poke the underlying dependencies (e.g. simulate an outage by closing
+// them mid-test) should call startFullServerWithDeps instead.
 func startFullServer(t *testing.T) (string, func()) {
+	t.Helper()
+	base, _, _, stop := startFullServerWithDeps(t)
+	return base, stop
+}
+
+// startFullServerWithDeps is startFullServer plus the live *store.Store
+// and *cache.Client driving the server. Returning them lets a test
+// simulate runtime dependency failure by calling Close on the dep --
+// subsequent /readyz Pings will fail and the handler should flip to 503.
+//
+// The returned deps are still owned by the helper: their Close is
+// already registered via t.Cleanup so calling it early in a test is
+// safe (both Close methods are no-ops or error-ignored on the second
+// call from cleanup).
+func startFullServerWithDeps(t *testing.T) (string, *store.Store, *cache.Client, func()) {
 	t.Helper()
 
 	dbURL := os.Getenv("URL_SHORTENER_TEST_DATABASE_URL")
@@ -91,7 +110,7 @@ func startFullServer(t *testing.T) (string, func()) {
 	}
 
 	waitForReady(t, "http://"+ln.Addr().String()+"/healthz")
-	return "http://" + ln.Addr().String(), stop
+	return "http://" + ln.Addr().String(), st, cc, stop
 }
 
 // httpClientNoRedirect is a non-following client so we can inspect 302s.

--- a/internal/server/server_integration_test.go
+++ b/internal/server/server_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -105,6 +106,88 @@ func TestServer_OperationalEndpointsOverRealNetwork(t *testing.T) {
 		code, _ := getJSON(t, base+"/no-such-thing")
 		if code != http.StatusNotFound {
 			t.Errorf("status = %d, want 404", code)
+		}
+	})
+}
+
+// TestServer_ReadyzReportsDependencyOutage verifies that /readyz flips to
+// 503 with a per-dependency error reason when one of the registered
+// readiness checks starts failing at runtime, not just at startup.
+//
+// Closing the live *store.Store / *cache.Client mid-test is the simplest
+// faithful way to fake an outage: the next Ping the readyz handler runs
+// against that dep returns "closed pool" / "client is closed", which is
+// the same shape of error the operator would see if the actual database
+// or redis instance went away. The handler-level unit test
+// (handlers/operational_test.go: TestReadyz_FailingCheckReturns503)
+// already covers the protocol contract with synthetic check funcs; this
+// test exercises the same code path against the real Pings wired into
+// server.New, so a regression there (e.g. someone wrapping the Ping with
+// silent error swallowing) gets caught.
+//
+// Each sub-test starts its own server because once a dep is closed it
+// stays closed for the lifetime of that helper call.
+func TestServer_ReadyzReportsDependencyOutage(t *testing.T) {
+	t.Run("postgres outage flips readyz to 503", func(t *testing.T) {
+		base, st, _, stop := startFullServerWithDeps(t)
+		defer stop()
+
+		// Sanity: both deps healthy at this point, /readyz must be 200.
+		if code, _ := getJSON(t, base+"/readyz"); code != http.StatusOK {
+			t.Fatalf("pre-outage readyz = %d, want 200", code)
+		}
+
+		// Simulate Postgres going away. pgxpool.Close is synchronous;
+		// the next Ping after this returns immediately with an error.
+		st.Close()
+
+		code, body := getJSON(t, base+"/readyz")
+		if code != http.StatusServiceUnavailable {
+			t.Fatalf("readyz = %d, want 503", code)
+		}
+		if body["status"] != "unready" {
+			t.Errorf("status = %v, want \"unready\"", body["status"])
+		}
+		pg, _ := body["postgres"].(string)
+		if !strings.HasPrefix(pg, "error:") {
+			t.Errorf("postgres = %q, want \"error: ...\" prefix", pg)
+		}
+		// Redis is untouched, so its check should still pass; this
+		// guards against the handler short-circuiting on the first
+		// failure and hiding the state of the other dep.
+		if body["redis"] != "ok" {
+			t.Errorf("redis = %v, want \"ok\"", body["redis"])
+		}
+	})
+
+	t.Run("redis outage flips readyz to 503", func(t *testing.T) {
+		base, _, cc, stop := startFullServerWithDeps(t)
+		defer stop()
+
+		if code, _ := getJSON(t, base+"/readyz"); code != http.StatusOK {
+			t.Fatalf("pre-outage readyz = %d, want 200", code)
+		}
+
+		// go-redis Close returns "client is closed" on the second call;
+		// the cleanup registered by the helper ignores that error, so
+		// closing here is fine.
+		if err := cc.Close(); err != nil {
+			t.Fatalf("cache.Close: %v", err)
+		}
+
+		code, body := getJSON(t, base+"/readyz")
+		if code != http.StatusServiceUnavailable {
+			t.Fatalf("readyz = %d, want 503", code)
+		}
+		if body["status"] != "unready" {
+			t.Errorf("status = %v, want \"unready\"", body["status"])
+		}
+		rd, _ := body["redis"].(string)
+		if !strings.HasPrefix(rd, "error:") {
+			t.Errorf("redis = %q, want \"error: ...\" prefix", rd)
+		}
+		if body["postgres"] != "ok" {
+			t.Errorf("postgres = %v, want \"ok\"", body["postgres"])
 		}
 	})
 }


### PR DESCRIPTION
Add `TestServer_ReadyzReportsDependencyOutage` (integration build tag): a real-server, real-Postgres, real-Redis test that closes one dep mid-flight and asserts `/readyz` switches to 503 with the failing dep's status reading "error: ..." while the other still reports "ok".

Why
===

The handler-level unit test
`handlers/operational_test.go::TestReadyz_FailingCheckReturns503` already exercises the protocol contract -- a synthetic check func that returns an error -> 503 + per-check status body. What it *doesn't* exercise is whether the real Pings wired into `server.New` (`store.Pool().Ping` and `cache.Ping`) actually propagate failure that way. A regression like wrapping the Ping in a goroutine that swallows the error, or moving the readiness check to a different layer that double-checks startup state instead of live state, would slip past the unit test entirely.

Closing the live `*store.Store` / `*cache.Client` is the simplest faithful way to fake the runtime outage without root, iptables, or container disruption: pgxpool's Close is synchronous and the next Ping returns a "closed pool" error immediately; go-redis behaves the same way with "client is closed". That's the same shape of error an operator sees when the actual database or redis instance disappears.

Implementation notes
====================

* Refactored `startFullServer` to delegate to a new `startFullServerWithDeps` that returns the underlying store + cache alongside the base URL and stop func. Most callers only need `(base, stop)` so `startFullServer` stays as a thin wrapper for backwards compatibility -- avoiding a churn-y signature change across every existing test.

* Each sub-test starts its own server because once a dep is Close()d it stays closed for the lifetime of that helper call, and the cleanups registered by the helper would call Close again (`cache.Client.Close` ignores the second-call error; `store.Store.Close` is a nil-guarded no-op when the pool is already closed).

* The "other dep still reports ok" assertion guards against the handler short-circuiting on the first failure -- operators rely on the per-check body to triage which dep is unhappy, so all registered checks must run on every call regardless of earlier failures.

Verified locally
================

  $ just test-integration 2>&1 | grep ReadyzReports
  === RUN   TestServer_ReadyzReportsDependencyOutage
  === RUN   TestServer_ReadyzReportsDependencyOutage/postgres_outage_flips_readyz_to_503
  === RUN   TestServer_ReadyzReportsDependencyOutage/redis_outage_flips_readyz_to_503
  --- PASS: TestServer_ReadyzReportsDependencyOutage (0.07s)
      --- PASS: .../postgres_outage_flips_readyz_to_503 (0.04s)
      --- PASS: .../redis_outage_flips_readyz_to_503 (0.04s)