### PR TITLE
ci: add compose-smoke job + factor checks into a Justfile recipe

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -187,6 +187,72 @@ jobs:
         if: always()
         run: docker compose --profile=test down -v
 
+  compose-smoke:
+    name: compose smoke test
+    # Bring up the `dev` profile of compose.yaml (the same stack a
+    # developer runs locally) and exercise the operational endpoints,
+    # the embedded static assets, and a real shorten -> fetch ->
+    # redirect cycle. Other CI jobs cover compile / unit / integration
+    # / scan in isolation; this is the one that catches "binary builds
+    # clean but the image doesn't actually serve" -- a missing COPY
+    # for an embedded asset, a Dockerfile drift away from what the
+    # binary expects, an env-var rename that silently broke a Postgres
+    # 18 connection string, etc. Keeps compose.yaml itself honest too:
+    # any field that drifts away from what the runner's compose plugin
+    # accepts breaks the PR rather than a developer's first `up --wait`.
+    #
+    # Runs in parallel with the `image` job below: both build the same
+    # Dockerfile independently. Sharing the GHA cache via compose's
+    # build block isn't worth threading through here -- `image` is the
+    # critical-path job (~2m), `compose-smoke` finishes well within
+    # that even with a cold build.
+    needs: go
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Compose v2 already drives BuildKit by default on hosted runners;
+      # making buildx explicit here is just defensive against future
+      # runner-image changes that flip the default back.
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      # The smoke-check script is encapsulated in a Justfile recipe
+      # (`just compose-smoke`) so dev iteration doesn't need a CI
+      # round-trip; setup-just installs the binary used to run it.
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+
+      # `--wait` blocks until each service's healthcheck reports
+      # healthy. The server's healthcheck invokes the binary's own
+      # `healthcheck` subcommand, which dials its own /healthz, so by
+      # the time `up` returns the listener is accepting traffic.
+      # AUTO_MIGRATE=true (set in compose.yaml) ensures the schema is
+      # applied before that point.
+      - name: docker compose --profile=dev up --wait
+        run: docker compose --profile=dev up --wait --detach
+
+      # The recipe targets http://localhost:8080 by default, which is
+      # the dev-profile published port. See Justfile::compose-smoke for
+      # the actual checks (operational endpoints, embedded static
+      # assets, full shorten -> fetch -> redirect cycle).
+      - name: just compose-smoke
+        run: just compose-smoke
+
+      # Always: dump server logs so a failure has its evidence in the
+      # job log without having to re-run with debug. `--no-color`
+      # keeps the output diffable; --tail caps log volume.
+      - name: docker compose logs (server)
+        if: always()
+        run: docker compose --profile=dev logs --no-color --tail=200 server
+
+      - name: docker compose --profile=dev down -v
+        if: always()
+        run: docker compose --profile=dev down -v
+
   binaries:
     name: binaries
     # Cross-compile the binary for linux/darwin x amd64/arm64 and upload

--- a/Justfile
+++ b/Justfile
@@ -251,6 +251,89 @@ trivy-image: docker-build
 tidy:
     go mod tidy
 
+# Smoke-check a running url-shortener stack: hit the operational endpoints
+# (`/healthz`, `/readyz`, `/version`), the embedded static assets, and a
+# real shorten -> fetch -> redirect cycle. The same script CI's
+# `compose-smoke` job runs against the `dev` compose profile after
+# `docker compose --profile=dev up --wait`, factored out here so a dev
+# can iterate on it locally without round-tripping through GitHub.
+#
+# Lifecycle stays with the caller: this recipe never starts or stops the
+# stack, so re-running it is cheap and never disturbs a long-lived dev
+# environment. Bring up the stack first; tear down when you're done:
+#
+#   docker compose --profile=dev up --wait -d
+#   just compose-smoke
+#   docker compose --profile=dev down -v
+#
+# `BASE_URL` defaults to the dev profile's published port; override for
+# alternate setups (e.g. a port-forwarded staging server). Requires curl
+# and jq on PATH; both ship preinstalled on the GitHub-hosted runners.
+[group("test")]
+compose-smoke BASE_URL="http://localhost:8080":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    base={{ quote(BASE_URL) }}
+
+    echo "== /healthz =="
+    curl --fail-with-body -sS "$base/healthz" \
+        | tee /dev/stderr | jq -e '.status == "ok"' >/dev/null
+
+    echo "== /readyz =="
+    curl --fail-with-body -sS "$base/readyz" \
+        | tee /dev/stderr \
+        | jq -e '.status == "ok" and .postgres == "ok" and .redis == "ok"' >/dev/null
+
+    echo "== /version =="
+    curl --fail-with-body -sS "$base/version" \
+        | tee /dev/stderr | jq -e 'has("version")' >/dev/null
+
+    # The HTML index references the embedded assets; a missing template
+    # parse would 5xx here long before we get a chance to look at the body.
+    echo "== / (web index) =="
+    body=$(curl --fail-with-body -sS "$base/")
+    # Match the rendered <title> rather than the package name -- the
+    # template's app title is "URL Shortener" (with a space), and
+    # this assertion proves the layout actually rendered rather than
+    # serving a stub or a 5xx.
+    echo "$body" | grep -qi "<title>URL Shortener</title>" \
+        || { echo "index page missing <title>URL Shortener</title>"; exit 1; }
+
+    # The web-builder Dockerfile stage emits styles.css / htmx.min.js /
+    # theme.js / copy.js into web/static/, then //go:embed bundles them
+    # into the binary. If any of these 404 the embed list and the
+    # Dockerfile have drifted apart -- the Go binary would still build
+    # clean, which is exactly the regression class this check catches.
+    echo "== embedded static assets =="
+    for asset in styles.css htmx.min.js theme.js copy.js; do
+        curl --fail-with-body -sS -o /dev/null "$base/static/$asset"
+    done
+
+    echo "== shorten -> fetch -> redirect =="
+    target="https://example.com/smoke/$(date +%s)"
+    code=$(curl --fail-with-body -sS -X POST "$base/api/v1/links" \
+        -H "content-type: application/json" \
+        -d "{\"target_url\":\"$target\"}" | jq -r .code)
+    test -n "$code" && test "$code" != null \
+        || { echo "create returned no code"; exit 1; }
+
+    # Round-trip the link via the JSON API.
+    curl --fail-with-body -sS "$base/api/v1/links/$code" \
+        | jq -e --arg t "$target" '.target_url == $t' >/dev/null
+
+    # Public redirect: expect 302 + Location header. -D - dumps response
+    # headers; -o /dev/null discards the body. We explicitly do not
+    # follow the redirect (no -L) so the status line we inspect is the
+    # redirect itself.
+    headers=$(curl -sS -D - -o /dev/null "$base/r/$code")
+    echo "$headers"
+    echo "$headers" | grep -qiE "^HTTP/[0-9.]+ 302" \
+        || { echo "expected 302"; exit 1; }
+    echo "$headers" | grep -qi "^location: $target" \
+        || { echo "expected Location: $target"; exit 1; }
+
+    echo "ok"
+
 # --- release ------------------------------------------------------------------
 
 # Lint just the most recent commit message.

--- a/README.md
+++ b/README.md
@@ -77,17 +77,22 @@ just test                              # run unit tests with -race -v -cover
 just test-integration                  # bring up test-profile infra, migrate, run -tags=integration tests
 just lint                              # run golangci-lint (auto-installs the pinned version)
 just govulncheck                       # run govulncheck against the latest Go vuln database
-just trivy-image                       # build the Docker image and scan it with Trivy (HIGH/CRITICAL)
-docker compose up --wait -d            # bring up the full local dev stack (db + redis + server on 5432/6379/8080)
-docker compose down -v                 # tear down the dev stack
-docker compose --profile=test down -v  # tear down the test-profile stack (db-test + redis-test on 5433/6380)
+just trivy-image                              # build the Docker image and scan it with Trivy (HIGH/CRITICAL)
+docker compose --profile=dev up --wait -d     # bring up the full local dev stack (db + redis + server on 5432/6379/8080)
+just compose-smoke                            # smoke-check a running stack: operational endpoints + shorten/redirect cycle
+docker compose --profile=dev down -v          # tear down the dev stack
+docker compose --profile=test down -v         # tear down the test-profile stack (db-test + redis-test on 5433/6380)
 ```
 
-The `compose.yaml` defines two stacks side by side: the **default** services
-(`db`, `redis`, `server`) for local dev on standard ports, and a **`test`
+The `compose.yaml` defines two stacks side by side: the **`dev` profile**
+(`db`, `redis`, `server`) for local dev on standard ports, and the **`test`
 profile** (`db-test`, `redis-test`) on alternate ports (5433, 6380) with
-their own volumes. Running the integration suite while a dev stack is up
-is therefore safe; the two never collide.
+their own volumes. Both profiles must be selected explicitly with
+`--profile=...` -- a bare `docker compose up` starts nothing. Running the
+integration suite while a dev stack is up is therefore safe; the two
+never collide. The CI `compose-smoke` job drives the `dev` profile end
+to end on every PR, so anything that breaks `up --wait` locally also
+breaks CI.
 
 The HTML UI is embedded in the binary via `//go:embed`, so the compiled
 assets in `web/static/` must exist at `go build` time. They're treated as

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,22 +1,33 @@
 # Local development & integration-test stack.
 #
-# Default services (no profile): `db`, `redis`, and `server` -- the full
-# local dev loop on standard ports (5432 / 6379 / 8080). Bring it up with
-# `docker compose up --wait -d`. The server has AUTO_MIGRATE=true so it
-# applies pending migrations before opening the listener; production
-# deploys should leave AUTO_MIGRATE off and run `migrate up` as a
-# separate one-shot step.
+# Two profiles, both selected explicitly:
 #
-# `test` profile: `db-test` and `redis-test` on alternate host ports
-# (5433 / 6380) with their own volumes. Used by `just test-integration`,
-# which runs the binary from the host. Alternate ports + volumes mean
-# the dev stack and the test stack can coexist without conflict, so a
-# running dev environment doesn't have to be torn down to run the
-# integration suite.
+#   `dev` profile  -- `db`, `redis`, `server`
+#     Full local dev loop on standard ports (5432 / 6379 / 8080).
+#     The server has AUTO_MIGRATE=true so it applies pending migrations
+#     before opening the listener; production deploys should leave
+#     AUTO_MIGRATE off and run `migrate up` as a separate one-shot.
+#     Same stack drives the CI compose-smoke job.
 #
-# Tear down with `docker compose --profile test down -v` -- the
-# `--profile test` flag is required to remove the test-only services.
-# Without it, only the default-profile services are removed.
+#       Bring up:  docker compose --profile=dev up --wait -d
+#       Tear down: docker compose --profile=dev down -v
+#
+#   `test` profile -- `db-test`, `redis-test`
+#     Isolated db + redis on alternate host ports (5433 / 6380) with
+#     their own volumes. Driven by `just test-integration`, which runs
+#     the binary from the host. Alternate ports + volumes mean dev and
+#     test stacks coexist, so a running dev environment doesn't have
+#     to be torn down to run the integration suite.
+#
+#       Bring up:  docker compose --profile=test up --wait -d
+#       Tear down: docker compose --profile=test down -v
+#
+# Every service belongs to exactly one profile, so a bare
+# `docker compose up` starts nothing. That's intentional: the previous
+# arrangement (default services + a test profile) had compose start the
+# default services *in addition to* test ones whenever `--profile=test`
+# was passed, because no-profile services run for every invocation.
+# Forcing both profiles to be opt-in eliminates that accidental overlap.
 
 name: url-shortener
 
@@ -51,8 +62,13 @@ x-redis-base: &redis-base
   restart: unless-stopped
 
 services:
+  # --- `dev` profile --------------------------------------------------------
+  # Full local dev loop and the same stack the CI compose-smoke job
+  # exercises. See file header for invocation.
+
   db:
     <<: *postgres-base
+    profiles: ["dev"]
     # Postgres 18+ expects a single mount at /var/lib/postgresql; the actual
     # data dir lives in a versioned subdirectory inside it (e.g. 18/docker).
     volumes:
@@ -62,6 +78,7 @@ services:
 
   redis:
     <<: *redis-base
+    profiles: ["dev"]
     volumes:
       - redis_data:/data
     ports:
@@ -71,6 +88,7 @@ services:
   # applies pending migrations before opening the listener, so the stack
   # is fully ready as soon as `up --wait` returns.
   server:
+    profiles: ["dev"]
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
Catch the regression class where the binary builds clean but the running container fails to actually serve -- a missing COPY for an embedded asset, a Dockerfile drift away from what the binary expects, an env-var rename that silently broke a Postgres 18 connection string, etc. Other CI jobs cover compile / unit / integration / scan in isolation; none of them ever execute the published image.

Three coordinated changes:

1. `compose.yaml`: every service in an explicit profile =======================================================

Previously `db`, `redis`, `server` had no `profiles:` field, which meant they ran on *every* compose invocation -- including `docker compose --profile=test up`, where the dev server would be brought up alongside `db-test` and `redis-test`. Compose's profile semantics are "no-profile services run in addition to whichever profiles you select", which is exactly the wrong default for our use case (dev and test should be isolated, not additive).

Now both profiles are opt-in:

  - `dev`  -- `db`, `redis`, `server`     (standard ports 5432 / 6379 / 8080)
  - `test` -- `db-test`, `redis-test`     (alternate ports 5433 / 6380)

Bare `docker compose up` starts nothing. Header comment rewritten to document the new model.

2. `Justfile::compose-smoke`: factored smoke-check script =========================================================

A new `compose-smoke BASE_URL="http://localhost:8080"` recipe under the `test` group that hits, against an already-running stack:

  - `/healthz`, `/readyz`, `/version` (operational endpoints)
  - `/` -- index page, asserting `<title>URL Shortener</title>` is in the rendered body, which only happens if the layout template parsed and the embedded assets resolved
  - `/static/{styles.css,htmx.min.js,theme.js,copy.js}` -- the four files the web-builder Dockerfile stage emits and `//go:embed` bundles into the binary; if any 404 the embed list and the Dockerfile have drifted apart
  - `POST /api/v1/links` -> `GET /api/v1/links/<code>` -> `GET /r/<code>` -- a real shorten-fetch-redirect cycle, with the redirect asserted via header inspection (no `-L`)

Lifecycle stays with the caller: the recipe never starts or stops the stack, so re-running it during dev iteration is cheap and never disturbs a long-lived environment. CI uses
`docker compose --profile=dev up --wait` first, then invokes the recipe.

3. `ci.yaml::compose-smoke`: new job calling the recipe =======================================================

Dependent on `go` (don't burn a runner spinning up compose if the binary doesn't even compile), parallel with `image` (both build the same Dockerfile independently; sharing the GHA cache through compose's build block isn't worth the complexity for the ~30s saved, since `image` is the critical-path job at ~2m).

Steps:

  1. harden-runner (audit) + checkout
  2. setup-buildx (defensive against future runner-image changes)
  3. setup-just (provides the runtime for step 5)
  4. `docker compose --profile=dev up --wait --detach`
  5. `just compose-smoke`
  6. always: `docker compose --profile=dev logs --tail=200 server` so failures have their evidence in the job log
  7. always: `docker compose --profile=dev down -v`

Verified locally
================

Bug caught during the local dry-run of the script: the original `grep -qi 'url-shortener'` against the index body never matched, because the rendered title is `URL Shortener` (with a space), not the package name. Fixed before commit by switching to `grep -qi '<title>URL Shortener</title>'`, which also doubles as a "the layout template actually rendered" assertion. End-to-end run locally:

  $ docker compose --profile=dev up --wait -d
  $ just compose-smoke
  == /healthz ==     {"status":"ok"}
  == /readyz ==      {"postgres":"ok","redis":"ok","status":"ok"}
  == /version ==     {"version":"dev","commit":"dev","date":...}
  == / (web index) ==
  == embedded static assets ==
  == shorten -> fetch -> redirect ==
  HTTP/1.1 302 Found
  Location: https://example.com/smoke/1777773783
  ok

  $ docker compose --profile=dev down -v