### PR TITLE
ci: add branch-protection-as-code via native rulesets

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,47 @@
+{
+  "name": "main-branch-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_linear_history" },
+    { "type": "required_signatures" },
+    { "type": "required_conversation_resolution" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "commitlint",                "integration_id": 15368 },
+          { "context": "go (build / test / lint)",  "integration_id": 15368 },
+          { "context": "govulncheck",               "integration_id": 15368 },
+          { "context": "trivy (image scan)",        "integration_id": 15368 },
+          { "context": "go (integration)",          "integration_id": 15368 },
+          { "context": "compose smoke test",        "integration_id": 15368 },
+          { "context": "binaries",                  "integration_id": 15368 },
+          { "context": "docker image",              "integration_id": 15368 },
+          { "context": "analyze (go)",              "integration_id": 15368 }
+        ]
+      }
+    }
+  ]
+}

--- a/.github/workflows/sync-rulesets.yaml
+++ b/.github/workflows/sync-rulesets.yaml
@@ -1,0 +1,127 @@
+# Apply branch-protection-as-code from `.github/rulesets/*.json` to the
+# repo's native ruleset configuration.
+#
+# Idempotent: each JSON file declares a `name`, the workflow looks the
+# ruleset up by name and either PUTs (update in place) or POSTs (create
+# new). Re-running on an unchanged file is a no-op as far as the
+# ruleset's enforcement is concerned -- GitHub returns 200 either way.
+#
+# Why a workflow rather than `terraform apply` from a developer laptop:
+# - state is the GitHub API itself, so there's no `tfstate` to keep
+#   anywhere; the JSON in this repo is the only source of truth
+# - reviewers can see the ruleset diff in the PR that changes it
+# - drift introduced through the GitHub UI is reverted on the next
+#   push that touches `.github/rulesets/`, which is the desired
+#   "infrastructure-as-code" property
+#
+# Why a separate workflow rather than a step in `ci.yaml`:
+# - it needs a different token (a PAT or App token with
+#   `Administration: write` -- the default `GITHUB_TOKEN` cannot
+#   manage rulesets); keeping the elevated credential out of the
+#   common CI path limits its blast radius if a CI step ever gets
+#   compromised
+# - it should only fire on changes that affect the ruleset
+#   definition, not on every PR
+#
+# Token setup (one-time, by a repo admin):
+# - Create a fine-grained PAT scoped to `vancanhuit/url-shortener`
+#   with `Administration: Read and write` permission
+# - Store it as the `RULESETS_TOKEN` repository secret
+# - Trigger this workflow once via "Run workflow" so the initial
+#   ruleset is applied; thereafter it runs automatically whenever
+#   anything under `.github/rulesets/` changes on `main`
+name: sync rulesets
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/rulesets/**
+      - .github/workflows/sync-rulesets.yaml
+  workflow_dispatch:
+
+# Default to no permissions on the GITHUB_TOKEN; the API calls below
+# use `RULESETS_TOKEN` instead. checkout still works against a public
+# repo without any contents:read permission, but we grant it for the
+# private-repo path too.
+permissions: {}
+
+# Serialize: two concurrent runs racing the same `PUT /rulesets/{id}`
+# would still converge (idempotent), but a stale run completing after
+# a newer one would overwrite the newer config. `cancel-in-progress`
+# avoids that by killing the older run when a newer one starts.
+concurrency:
+  group: sync-rulesets
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: sync repository rulesets
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Fail fast with a clear message when the PAT secret is missing.
+      # Without this, `gh api` would emit a generic "HTTP 401: Bad
+      # credentials" that doesn't point at the cause.
+      - name: verify RULESETS_TOKEN is set
+        env:
+          RULESETS_TOKEN: ${{ secrets.RULESETS_TOKEN }}
+        run: |
+          if [ -z "${RULESETS_TOKEN:-}" ]; then
+            echo "::error::RULESETS_TOKEN secret is not set. See README ('Branch protection' section) for the one-time PAT setup."
+            exit 1
+          fi
+
+      # `gh api` reads $GH_TOKEN; explicitly passing the PAT keeps the
+      # default GITHUB_TOKEN out of the call (it lacks the required
+      # `Administration: write` scope anyway, but defense in depth).
+      #
+      # For each JSON file under .github/rulesets/, look up the
+      # ruleset by its declared `name`. If found, PUT to update in
+      # place; otherwise POST to create. The API tolerates the same
+      # JSON shape for both verbs (the URL path carries the id on
+      # PUT, and any `id` field in the body is ignored).
+      - name: apply rulesets
+        env:
+          GH_TOKEN: ${{ secrets.RULESETS_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          rulesets=(.github/rulesets/*.json)
+          if [ ${#rulesets[@]} -eq 0 ]; then
+            echo "::warning::no ruleset files under .github/rulesets/"
+            exit 0
+          fi
+
+          # List existing rulesets once; reuse for every file.
+          existing=$(gh api "/repos/$REPO/rulesets")
+
+          for file in "${rulesets[@]}"; do
+            name=$(jq -r '.name' "$file")
+            if [ -z "$name" ] || [ "$name" = "null" ]; then
+              echo "::error file=$file::missing top-level 'name' field"
+              exit 1
+            fi
+
+            id=$(echo "$existing" | jq -r --arg n "$name" '.[] | select(.name == $n) | .id')
+
+            if [ -n "$id" ] && [ "$id" != "null" ]; then
+              echo "== updating ruleset name=$name id=$id =="
+              gh api --method PUT "/repos/$REPO/rulesets/$id" \
+                --input "$file" \
+                --jq '{name, target, enforcement, rules: [.rules[].type]}'
+            else
+              echo "== creating ruleset name=$name =="
+              gh api --method POST "/repos/$REPO/rulesets" \
+                --input "$file" \
+                --jq '{id, name, target, enforcement, rules: [.rules[].type]}'
+            fi
+          done

--- a/README.md
+++ b/README.md
@@ -391,6 +391,163 @@ Pull-request OCI tarballs (`oci-image-pr-<N>`) carry the same
 attestations, so reviewers can run the same commands against a
 loaded image.
 
+## Branch protection
+
+Branch-protection rules for `main` live in
+[`.github/rulesets/main.json`](.github/rulesets/main.json) as a native
+GitHub repository ruleset. The
+[`sync-rulesets`](.github/workflows/sync-rulesets.yaml) workflow
+applies it via `gh api` on every push that touches the JSON, so
+the file in the repo is the single source of truth. Drift introduced
+through the GitHub UI is reverted on the next sync run.
+
+The active ruleset enforces, on `main` only:
+
+- **Pull-request only** &mdash; no direct pushes (review count is 0;
+  the gate is the PR, not an approver)
+- **Required CI checks** &mdash; `commitlint`, `go (build / test / lint)`,
+  `govulncheck`, `trivy (image scan)`, `go (integration)`,
+  `compose smoke test`, `binaries`, `docker image`, `analyze (go)`.
+  PR branches must be up-to-date with `main` before merging.
+- **Linear history** &mdash; squash- or rebase-merge only, no merge
+  commits
+- **Signed commits** &mdash; every commit must carry a verified GPG /
+  SSH / S/MIME signature (see [Setting up signed commits](#setting-up-signed-commits)
+  below); configure a signing key on your GitHub account before
+  opening a PR
+- **Block force-push and deletion** of `main`
+- **Resolve all PR conversations** before merging
+
+### One-time setup
+
+The workflow needs a token with `Administration: write` on this repo;
+the default `GITHUB_TOKEN` deliberately lacks that scope. Steps for
+a repo admin:
+
+1. Create a fine-grained PAT scoped to `vancanhuit/url-shortener`
+   with `Repository permissions > Administration: Read and write`.
+2. Store it as the `RULESETS_TOKEN` repository secret.
+3. Trigger the `sync rulesets` workflow once via "Run workflow" so
+   the initial ruleset is applied. After that it runs automatically
+   whenever anything under `.github/rulesets/` changes on `main`.
+
+### Verifying current state
+
+```sh
+# List all active rulesets on the repo:
+gh api /repos/vancanhuit/url-shortener/rulesets
+
+# Inspect the live `main-branch-protection` ruleset and diff it
+# against the committed JSON:
+gh api "/repos/vancanhuit/url-shortener/rulesets/$(\
+    gh api /repos/vancanhuit/url-shortener/rulesets \
+        --jq '.[] | select(.name=="main-branch-protection") | .id')" \
+    | diff -u .github/rulesets/main.json -
+```
+
+A non-empty diff means someone changed the ruleset through the UI;
+either re-run the `sync rulesets` workflow (to revert) or update the
+JSON in a PR (to adopt the change).
+
+### Setting up signed commits
+
+The ruleset rejects unsigned commits on `main`, so every PR must be
+signed before it can merge. GPG, SSH, and S/MIME signatures all
+satisfy GitHub's verification check; the snippets below cover GPG on
+Linux because that's what this repo's maintainer uses. For other
+platforms or methods see GitHub's docs on
+[signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
+
+> **Note:** the email on your GPG UID must match a verified email on
+> your GitHub account, otherwise the signature is mathematically
+> valid but GitHub still shows _Unverified_. Check your verified
+> emails at [Settings -> Emails](https://github.com/settings/emails).
+
+#### One-time key setup
+
+```sh
+# 1. Generate an ed25519 signing key (prompts for a passphrase;
+#    `gpg-agent` caches it for the rest of the session).
+gpg --quick-generate-key "$(git config --global user.name) <$(git config --global user.email)>" \
+    ed25519 sign 2y
+
+# 2. Configure git to sign every commit / tag / rebase output.
+KEY_ID=$(gpg --list-secret-keys --keyid-format=long --with-colons "$(git config --global user.email)" \
+            | awk -F: '/^sec/ { print $5; exit }')
+git config --global gpg.format openpgp
+git config --global user.signingkey "$KEY_ID"
+git config --global commit.gpgsign true
+git config --global tag.gpgsign true
+git config --global rebase.gpgsign true
+
+# 3. Make sure pinentry can prompt on the current TTY.
+grep -q 'GPG_TTY' ~/.zshrc 2>/dev/null \
+    || echo 'export GPG_TTY=$(tty)' >> ~/.zshrc
+export GPG_TTY=$(tty)
+
+# 4. Print the armored public key and paste it into
+#    https://github.com/settings/gpg/new
+gpg --armor --export "$KEY_ID"
+```
+
+Verify a fresh commit shows up as **Verified** on the GitHub UI
+before merging anything that's gated by the ruleset:
+
+```sh
+git checkout -b test/gpg-signing-sanity
+git commit --allow-empty -m "chore: gpg signing sanity check"
+git log --show-signature -1   # should print "Good signature from ..."
+git push -u origin test/gpg-signing-sanity
+gh pr view --web              # the commit must show "Verified"
+gh pr close --delete-branch
+```
+
+#### Re-signing existing commits
+
+If a PR branch was opened before signing was set up, the existing
+commits are unsigned and the merge will be rejected. Re-sign in
+place and force-push:
+
+```sh
+# Single-commit branch -- amend, then force-push.
+git commit --amend --no-edit -S
+git push --force-with-lease
+
+# Multi-commit branch -- rebase --exec re-creates each commit signed.
+# (`rebase.gpgsign=true` from the setup above also signs commits
+# created by a plain `git rebase main`, but --exec is explicit.)
+git rebase --exec 'git commit --amend --no-edit -S' main
+git push --force-with-lease
+```
+
+#### Common Linux gotchas
+
+- **`error: gpg failed to sign the data ... Inappropriate ioctl for device`**
+  &mdash; `GPG_TTY` is unset in the current shell. Re-run
+  `export GPG_TTY=$(tty)`; the snippet above also persists it.
+- **Passphrase prompt on every commit** &mdash; `gpg-agent`'s default
+  cache TTL is short. Bump it in `~/.gnupg/gpg-agent.conf`:
+
+  ```
+  default-cache-ttl 28800
+  max-cache-ttl 86400
+  ```
+
+  Then `gpgconf --kill gpg-agent` so the next commit picks up the
+  new TTL.
+- **`gpg: Can't check signature: No public key` on older commits**
+  &mdash; harmless; those were signed by GitHub's web-flow key,
+  which is just not in your local keyring. Import it once if the
+  warning bothers you:
+
+  ```sh
+  curl -sS https://github.com/web-flow.gpg | gpg --import
+  ```
+
+- **Squash-merge** &mdash; the merge commit is signed by GitHub's
+  web-flow key, so `required_signatures` is satisfied even when
+  squashing. Squash-merge keeps working unchanged.
+
 ## License
 
 To be added.


### PR DESCRIPTION
Codify `main`'s branch protection in `.github/rulesets/main.json` and apply it on every push that changes the file via a new `sync-rulesets` workflow. The JSON in this repo is the single source of truth -- drift introduced through the GitHub UI is reverted on the next sync run.

Why native rulesets rather than `.github/settings.yml` (settings App) or Terraform:
- no third-party GitHub App with admin permissions to install / trust on the repo
- no `tfstate` to keep anywhere -- the GitHub API itself is the state, and the JSON is just `desired = state` declarations
- reviewers see the ruleset diff in the PR that changes it, same as any other code change
- consistent with the repo's other "fewer external moving parts" decisions (action SHA pinning, in-repo recipes, etc.)

Why a separate workflow rather than a step in `ci.yaml`:
- needs `Administration: write`, which the default `GITHUB_TOKEN` deliberately lacks; the elevated PAT (`RULESETS_TOKEN` secret) is best kept out of the common CI path to limit blast radius
- only fires on changes that actually affect the ruleset, not on every PR -- the API call is idempotent but pointless to repeat

Ruleset on `main`
=================

- pull-request-only access -- no direct pushes (review count is 0; the gate is the PR existence + checks, not approvers, since this is a single-maintainer repo)
- required CI status checks: `commitlint`, `go (build / test / lint)`, `govulncheck`, `trivy (image scan)`, `go (integration)`, `compose smoke test`, `binaries`, `docker image`, `analyze (go)` -- the union of `ci.yaml` and `codeql.yaml` job names; PR branches must be up-to-date with `main` before merging (`strict_required_status_checks_policy`)
- linear history -- squash- or rebase-merge only
- signed commits required (GPG / SSH / S/MIME)
- conversation resolution required before merge
- block force-push (`non_fast_forward`) and deletion
- empty bypass list -- the rule applies uniformly to everyone, including the repo owner

`integration_id: 15368` is set explicitly on every required check so an external check service publishing the same context name cannot satisfy a requirement intended to gate on GitHub Actions.

Sync workflow
=============

`.github/workflows/sync-rulesets.yaml`:
- triggers on push to `main` when `.github/rulesets/**` or the workflow itself changes; also `workflow_dispatch` for the one-time bootstrap before any push touches the directory
- `permissions: {}` at the workflow level; the `sync` job grants itself only `contents: read` (everything ruleset-related goes through the PAT, not GITHUB_TOKEN)
- `concurrency: { cancel-in-progress: true }` so a stale run finishing after a newer one cannot overwrite the newer config
- harden-runner audit + checkout pinned to SHAs, matching the rest of the workflows
- pre-flight check fails fast with a clear error if `RULESETS_TOKEN` isn't set (otherwise gh would emit a generic 401)
- the apply loop walks every JSON under `.github/rulesets/`, looks the ruleset up by its `name` field via a single GET, then PUTs to update or POSTs to create

One-time setup (documented in README)
=====================================

A repo admin needs to:
1. Create a fine-grained PAT scoped to `vancanhuit/url-shortener` with `Administration: Read and write`
2. Store it as the `RULESETS_TOKEN` secret
3. Trigger the `sync rulesets` workflow once via "Run workflow"

After that the workflow runs automatically on JSON changes.

Verification
============

`README.md` includes the `gh api` invocation that diffs the live ruleset against the committed JSON, so a maintainer can confirm "what's actually enforced right now" without trusting the UI.