### PR TITLE
ci(rulesets): fix 422, replace existing rulesets, codify tag protection

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,5 +1,5 @@
 {
-  "name": "main-branch-protection",
+  "name": "main",
   "target": "branch",
   "enforcement": "active",
   "bypass_actors": [],
@@ -13,8 +13,6 @@
     { "type": "deletion" },
     { "type": "non_fast_forward" },
     { "type": "required_linear_history" },
-    { "type": "required_signatures" },
-    { "type": "required_conversation_resolution" },
     {
       "type": "pull_request",
       "parameters": {
@@ -22,7 +20,9 @@
         "dismiss_stale_reviews_on_push": true,
         "require_code_owner_review": false,
         "require_last_push_approval": false,
-        "required_review_thread_resolution": false
+        "required_review_thread_resolution": true,
+        "required_reviewers": [],
+        "allowed_merge_methods": ["squash", "rebase"]
       }
     },
     {
@@ -42,6 +42,7 @@
           { "context": "analyze (go)",              "integration_id": 15368 }
         ]
       }
-    }
+    },
+    { "type": "required_signatures" }
   ]
 }

--- a/.github/rulesets/semver-tag.json
+++ b/.github/rulesets/semver-tag.json
@@ -1,0 +1,17 @@
+{
+  "name": "semver-tag",
+  "target": "tag",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/tags/v*"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_linear_history" }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -393,15 +393,18 @@ loaded image.
 
 ## Branch protection
 
-Branch-protection rules for `main` live in
-[`.github/rulesets/main.json`](.github/rulesets/main.json) as a native
-GitHub repository ruleset. The
+Branch- and tag-protection rules live in
+[`.github/rulesets/`](.github/rulesets/) as native GitHub repository
+rulesets, one JSON file per ruleset. The
 [`sync-rulesets`](.github/workflows/sync-rulesets.yaml) workflow
-applies it via `gh api` on every push that touches the JSON, so
-the file in the repo is the single source of truth. Drift introduced
-through the GitHub UI is reverted on the next sync run.
+walks every file in that directory and applies it via `gh api` on
+every push that touches the JSON, so the files in the repo are the
+single source of truth. Drift introduced through the GitHub UI is
+reverted on the next sync run.
 
-The active ruleset enforces, on `main` only:
+### `main.json` (target: branch)
+
+Applies to the default branch (`~DEFAULT_BRANCH`) and enforces:
 
 - **Pull-request only** &mdash; no direct pushes (review count is 0;
   the gate is the PR, not an approver)
@@ -409,14 +412,29 @@ The active ruleset enforces, on `main` only:
   `govulncheck`, `trivy (image scan)`, `go (integration)`,
   `compose smoke test`, `binaries`, `docker image`, `analyze (go)`.
   PR branches must be up-to-date with `main` before merging.
-- **Linear history** &mdash; squash- or rebase-merge only, no merge
-  commits
+- **Linear history** &mdash; the merge UI only offers _Squash and
+  merge_ and _Rebase and merge_ (`allowed_merge_methods` on the
+  `pull_request` rule); plain merge commits would also be rejected
+  by `required_linear_history`
 - **Signed commits** &mdash; every commit must carry a verified GPG /
   SSH / S/MIME signature (see [Setting up signed commits](#setting-up-signed-commits)
   below); configure a signing key on your GitHub account before
   opening a PR
 - **Block force-push and deletion** of `main`
 - **Resolve all PR conversations** before merging
+
+### `semver-tag.json` (target: tag)
+
+Applies to every tag matching `refs/tags/v*` (i.e. semver release tags
+created by the `release.yaml` workflow) and enforces:
+
+- **Block deletion** &mdash; published releases are immutable;
+  `git push --delete origin v1.2.3` is rejected
+- **Block force-push** (`non_fast_forward`) &mdash; an existing tag
+  cannot be re-pointed at a different commit
+- **Linear history** &mdash; included for parity with the manually
+  configured ruleset this replaced; on tags it has no behavioural
+  effect since tags don't have history of their own
 
 ### One-time setup
 
@@ -437,12 +455,17 @@ a repo admin:
 # List all active rulesets on the repo:
 gh api /repos/vancanhuit/url-shortener/rulesets
 
-# Inspect the live `main-branch-protection` ruleset and diff it
-# against the committed JSON:
+# Inspect the live `main` ruleset and diff it against the committed JSON.
+# `jq -S` normalizes object-key order on both sides; the JSON is also
+# crafted to round-trip the API's server-side defaults (e.g. the
+# `pull_request` rule's `required_reviewers: []`), so a clean apply
+# produces an empty diff.
 gh api "/repos/vancanhuit/url-shortener/rulesets/$(\
     gh api /repos/vancanhuit/url-shortener/rulesets \
-        --jq '.[] | select(.name=="main-branch-protection") | .id')" \
-    | diff -u .github/rulesets/main.json -
+        --jq '.[] | select(.name=="main") | .id')" \
+    | jq -S '{name, target, enforcement, conditions, bypass_actors, rules}' \
+    | diff -u <(jq -S '{name, target, enforcement, conditions, bypass_actors, rules}' \
+                   .github/rulesets/main.json) -
 ```
 
 A non-empty diff means someone changed the ruleset through the UI;


### PR DESCRIPTION
Four coupled fixes after the first sync-rulesets run on main hit HTTP 422 and the manually-configured rulesets were discovered:

1. Drop required_conversation_resolution =========================================

The repository ruleset API rejects required_conversation_resolution as a top-level rule type:

    Invalid property /rules/4: data matches no possible input. (HTTP 422)

Conversation resolution is exposed as the
required_review_thread_resolution parameter on the pull_request rule, not as its own rule. Drop the invalid entry and flip the parameter to true so the documented behavior ("resolve all PR conversations before merging") stays enforced.

2. Rename main-branch-protection -> main =========================================

A manually-configured ruleset named "main" was already active on the repo (id 15657603) before this workflow existed. Our JSON declared a different name, so the workflow's name-lookup would have created a third ruleset alongside it instead of replacing it. Rename to "main" so the workflow's PUT replaces the existing ruleset in place. PUT is atomic: an invalid JSON 422s and the existing ruleset stays unchanged.

3. Restrict merge methods to squash + rebase =============================================

Add allowed_merge_methods: ["squash", "rebase"] to the pull_request rule. The merge-commit method was already effectively blocked at push time by required_linear_history, but the merge UI button still offered "Create a merge commit" -- a footgun that produced a clear error after clicking. Removing it from
allowed_merge_methods hides it from the dropdown.

Also adds required_reviewers: [] (server-default empty list) and moves required_signatures to the end of the rules array, so the committed JSON round-trips byte-for-byte against the API. The README's drift-detection diff command now produces an empty diff on a clean apply, rather than always-noisy server normalization.

4. Codify the semver-tag ruleset =================================

The manually-configured semver-tag ruleset (id 15657763) was also discovered: target=tag, conditions=refs/tags/v*, rules=[deletion, non_fast_forward, required_linear_history]. Codify it as .github/rulesets/semver-tag.json with identical rules so the same sync-rulesets workflow can manage it, replacing the live ruleset in place. No semantic changes -- the IaC plumbing is the value-add; future tweaks (e.g. requiring signed tags) are separate PRs.

Verified locally
================

Generalised /tmp/apply-rulesets.sh to walk every JSON under .github/rulesets/ (mirroring the workflow exactly) and ran it:

  $ bash /tmp/apply-rulesets.sh
  == PUT name=main id=15657603 ==
     round-trip clean
  == PUT name=semver-tag id=15657763 ==
     round-trip clean

Both rulesets are therefore already enforced as of this commit -- the next sync-rulesets workflow run after merge will be an idempotent no-op (PUT with identical body returns 200, no state change).

Documentation updates
=====================

- "Branch protection" section restructured into per-ruleset subsections (### main.json (target: branch) and ### semver-tag.json (target: tag)) so each ruleset has its own description.
- README's "Linear history" bullet now describes the merge-method restriction explicitly.
- README's drift-detection command updated for the renamed ruleset and uses jq -S on both sides for stable comparison.