### PR TITLE
feat(server): add TLS support and proxy-aware request handling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -253,6 +253,59 @@ jobs:
         if: always()
         run: docker compose --profile=dev down -v
 
+  compose-tls-smoke:
+    name: compose tls smoke test
+    # Bring up the `tls` profile (server-tls + db + redis) with a
+    # mkcert-issued cert generated into an isolated CAROOT, then
+    # verify HTTPS works end-to-end via `curl --cacert`. This is the
+    # production counterpart of `compose-smoke`: same checks, but
+    # against the TLS-terminating variant of the binary, exercising
+    # the cfg.TLSCertFile branch of server.Serve in the same image
+    # users actually deploy.
+    #
+    # The recipe (`just tls-smoke`) handles everything -- mkcert
+    # CAROOT in a tempdir (no host-trust install), compose lifecycle
+    # via trap, and a negative check that omitting --cacert fails
+    # TLS verification. See Justfile::tls-smoke for details.
+    needs: go
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+
+      # mkcert is preinstalled on `ubuntu-latest` (`ubuntu-24.04`)
+      # GitHub-hosted runners as of late 2025; this step is a defensive
+      # fallback so a future runner-image change that drops it doesn't
+      # silently break the smoke test. The apt path also gives us
+      # libnss3-tools, which mkcert calls when populating its CAROOT
+      # (we never run `mkcert -install`, but the dependency is tiny).
+      - name: install mkcert (if missing)
+        run: |
+          if ! command -v mkcert >/dev/null 2>&1; then
+            sudo apt-get update -y
+            sudo apt-get install -y --no-install-recommends mkcert libnss3-tools
+          fi
+          mkcert -version
+
+      - name: just tls-smoke
+        run: just tls-smoke
+
+      # Always: dump server-tls logs so a failure has its evidence in
+      # the job log. The recipe's trap already runs `down -v`, so by
+      # this point the container is gone -- but `logs` still works
+      # against stopped containers until compose's network is removed,
+      # which the trap also does. Use `|| true` so log retrieval failure
+      # never masks a real test failure.
+      - name: docker compose logs (server-tls)
+        if: always()
+        run: docker compose --profile=tls logs --no-color --tail=200 server-tls || true
+
   binaries:
     name: binaries
     # Cross-compile the binary for linux/darwin x amd64/arm64 and upload

--- a/Justfile
+++ b/Justfile
@@ -375,6 +375,98 @@ compose-smoke BASE_URL="http://localhost:8080":
 
     echo "ok"
 
+# Smoke-test the `tls` compose profile end-to-end with an isolated
+# mkcert root CA. Unlike `just dev-certs` this never touches the
+# host's trust store (no `mkcert -install`); the leaf cert is
+# verified through `curl --cacert` against the just-created root,
+# which is exactly the pattern CI needs and a useful regression
+# check for the TLS path locally.
+#
+# What the recipe does, in order:
+#
+#   1. Allocate a tempdir as CAROOT and mkcert-write the root CA
+#      + leaf cert there. Both die with the tempdir at the end.
+#   2. Bring up `--profile=tls` with TLS_CERTS_DIR pointing at the
+#      tempdir's certs/ subdir, so the existing `dev/certs/`
+#      contents are untouched.
+#   3. Hit /healthz, /readyz, /version over HTTPS with
+#      `--cacert <tempdir>/rootCA.pem` -- a strict check that the
+#      server is actually serving the cert we just signed.
+#   4. Tear down on exit (success or failure) via trap.
+#
+# Requires mkcert + curl + jq on PATH. mkcert install instructions
+# are in the dev-certs recipe doc-comment.
+[group("test")]
+tls-smoke:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if ! command -v mkcert >/dev/null 2>&1; then
+        echo 'mkcert not found on PATH; see `just dev-certs` for install instructions.' >&2
+        exit 1
+    fi
+
+    workdir=$(mktemp -d -t url-shortener-tls-smoke-XXXXXX)
+    export TLS_CERTS_DIR="$workdir/certs"
+    mkdir -p "$TLS_CERTS_DIR"
+
+    cleanup() {
+        local rc=$?
+        echo "== teardown =="
+        docker compose --profile=tls down -v --remove-orphans >/dev/null 2>&1 || true
+        rm -rf "$workdir"
+        exit $rc
+    }
+    trap cleanup EXIT
+
+    echo "== mkcert (isolated CAROOT=$workdir/ca) =="
+    # CAROOT redirects mkcert's CA storage; -install is intentionally
+    # omitted so the host trust store stays unchanged. The leaf cert
+    # is signed for localhost + 127.0.0.1 + ::1 to match what the
+    # compose service binds.
+    export CAROOT="$workdir/ca"
+    mkdir -p "$CAROOT"
+    mkcert \
+        -cert-file "$TLS_CERTS_DIR/cert.pem" \
+        -key-file  "$TLS_CERTS_DIR/key.pem" \
+        localhost 127.0.0.1 ::1 >/dev/null
+    # Distroless container's nonroot UID needs world-readable key
+    # to read it through the bind mount; matches what dev-certs
+    # does for the same reason.
+    chmod 0644 "$TLS_CERTS_DIR/key.pem"
+    cacert="$CAROOT/rootCA.pem"
+    test -f "$cacert" || { echo "rootCA.pem not at $cacert" >&2; exit 1; }
+
+    echo "== docker compose --profile=tls up --wait =="
+    docker compose --profile=tls up --wait --detach
+
+    base="https://localhost:8443"
+
+    echo "== /healthz (curl --cacert) =="
+    curl --fail-with-body -sS --cacert "$cacert" "$base/healthz" \
+        | tee /dev/stderr | jq -e '.status == "ok"' >/dev/null
+
+    echo "== /readyz =="
+    curl --fail-with-body -sS --cacert "$cacert" "$base/readyz" \
+        | tee /dev/stderr \
+        | jq -e '.status == "ok" and .postgres == "ok" and .redis == "ok"' >/dev/null
+
+    echo "== /version =="
+    curl --fail-with-body -sS --cacert "$cacert" "$base/version" \
+        | tee /dev/stderr | jq -e 'has("version")' >/dev/null
+
+    # Negative check: without --cacert (no host-trust install), the
+    # request must fail at TLS verification. Proves the certificate
+    # chain is genuinely walked rather than e.g. the compose stack
+    # serving a default fallback that happens to match.
+    echo "== curl without --cacert must fail TLS verification =="
+    if curl --fail-with-body -sS -o /dev/null "$base/healthz" 2>/dev/null; then
+        echo "expected TLS verification failure, got success" >&2
+        exit 1
+    fi
+
+    echo "ok"
+
 # --- release ------------------------------------------------------------------
 
 # Lint just the most recent commit message.

--- a/Justfile
+++ b/Justfile
@@ -307,14 +307,17 @@ tidy:
 #   just compose-smoke
 #   docker compose --profile=dev down -v
 #
-# `BASE_URL` defaults to the dev profile's published port; override for
-# alternate setups (e.g. a port-forwarded staging server). Requires curl
-# and jq on PATH; both ship preinstalled on the GitHub-hosted runners.
+# Targets the dev profile's published port directly; the smoke is
+# tightly coupled to that stack (it asserts the embedded static
+# assets, the shorten/redirect cycle, etc.) so making the URL
+# configurable just invited misuse against unrelated environments.
+# Requires curl and jq on PATH; both ship preinstalled on the
+# GitHub-hosted runners.
 [group("test")]
-compose-smoke BASE_URL="http://localhost:8080":
+compose-smoke:
     #!/usr/bin/env bash
     set -euo pipefail
-    base={{ quote(BASE_URL) }}
+    base="http://localhost:8080"
 
     echo "== /healthz =="
     curl --fail-with-body -sS "$base/healthz" \

--- a/Justfile
+++ b/Justfile
@@ -106,6 +106,47 @@ run *ARGS:
 version:
     @go run ./cmd/url-shortener version 2>/dev/null || echo "Version (resolved): {{ VERSION }}"
 
+# Generate a host-trusted dev TLS cert + key into dev/certs/ via mkcert.
+# Both files are gitignored; every contributor regenerates locally.
+#
+# Prerequisites: mkcert (https://github.com/FiloSottile/mkcert).
+#   - Linux (apt-based): `sudo apt install -y libnss3-tools && \
+#     curl -L -o ~/.local/bin/mkcert "https://dl.filippo.io/mkcert/latest?for=linux/amd64" && \
+#     chmod +x ~/.local/bin/mkcert`
+#   - macOS:             `brew install mkcert nss`
+#
+# `mkcert -install` is idempotent and only needs to run once per host
+# to add mkcert's local CA to the system + browser trust stores. The
+# cert is valid for localhost / 127.0.0.1 / ::1, which covers both the
+# `tls`-profile compose stack and a binary running directly on the host.
+[group("dev")]
+dev-certs:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! command -v mkcert >/dev/null 2>&1; then
+        echo 'mkcert not found on PATH; see the recipe doc-comment for install instructions.' >&2
+        exit 1
+    fi
+    mkcert -install >/dev/null
+    mkdir -p dev/certs
+    mkcert \
+        -cert-file dev/certs/cert.pem \
+        -key-file  dev/certs/key.pem \
+        localhost 127.0.0.1 ::1
+    # mkcert writes the key with 0600. The compose `tls` profile mounts
+    # dev/certs into a distroless container where the binary runs as
+    # UID 65532 (nonroot), so it can't read a host-uid-owned 0600 file.
+    # Relax to 0644 -- this is dev-only material, gitignored, never
+    # production.
+    chmod 0644 dev/certs/key.pem
+    echo
+    echo "Wrote dev/certs/cert.pem + dev/certs/key.pem (gitignored, 0644 for compose readability)."
+    echo "Use them via:"
+    echo "    URL_SHORTENER_TLS_CERT_FILE=dev/certs/cert.pem \\"
+    echo "    URL_SHORTENER_TLS_KEY_FILE=dev/certs/key.pem \\"
+    echo "    ./bin/url-shortener run"
+    echo "or with the compose 'tls' profile: docker compose --profile tls up"
+
 # --- test ---------------------------------------------------------------------
 
 # Run all unit tests with verbose output and per-package coverage.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ local `compose.yaml` overrides them for development.
 | `URL_SHORTENER_DB_MAX_CONN_LIFETIME`   | _(pgx default: 1h)_             | Hard cap on a connection's age. Forces rotation through floating-IP failovers and clears DB-side connection-state drift. Accepts Go duration syntax (e.g. `30m`, `2h`). |
 | `URL_SHORTENER_DB_MAX_CONN_IDLE_TIME`  | _(pgx default: 30m)_            | How long a connection may sit unused before being closed. |
 | `URL_SHORTENER_DB_HEALTH_CHECK_PERIOD` | _(pgx default: 1m)_             | How often pgx scans the pool for stale connections. |
+| `URL_SHORTENER_TLS_CERT_FILE`  | _(empty)_                     | Path to a PEM-encoded server certificate. When set together with `URL_SHORTENER_TLS_KEY_FILE`, the server speaks HTTPS on `URL_SHORTENER_ADDR`; otherwise it stays on plain HTTP (the right choice when fronted by a TLS-terminating reverse proxy). Both must be set together -- one without the other is a startup error. See [Deployment](#deployment). |
+| `URL_SHORTENER_TLS_KEY_FILE`   | _(empty)_                     | Path to the PEM-encoded private key matching `URL_SHORTENER_TLS_CERT_FILE`. |
+| `URL_SHORTENER_TRUSTED_PROXIES` | _(empty)_                    | Comma-separated CIDR list (e.g. `127.0.0.1/32,10.0.0.0/8`). When a request's `RemoteAddr` falls inside one of these ranges the server walks `X-Forwarded-For` to find the original client IP; otherwise XFF is ignored. Empty leaves no proxy trust configured -- safe default for direct-to-internet deployments. See [Reverse-proxy deployment (Caddy)](#reverse-proxy-deployment-caddy). |
 
 Pool tunables are zero by default, in which case pgx's own defaults apply.
 Production deployments behind a fronting proxy (PgBouncer, RDS Proxy)
@@ -282,6 +285,110 @@ dependencies (`config.Validate` rejects an empty
 `URL_SHORTENER_DATABASE_URL` or `URL_SHORTENER_REDIS_URL` at startup).
 Each check has its own line in the JSON body so operators can see
 which dependency is unhappy.
+
+## Deployment
+
+The binary supports two TLS-aware deployment shapes: terminating TLS
+itself with a static cert + key, or speaking plain HTTP behind a
+TLS-terminating reverse proxy (Caddy, nginx, Traefik, ...). Pick one;
+they are mutually exclusive.
+
+### Direct TLS on the binary
+
+Set `URL_SHORTENER_TLS_CERT_FILE` and `URL_SHORTENER_TLS_KEY_FILE` to
+PEM-encoded paths. Both must be set together -- a half-configured
+pair is a startup error. The server then listens HTTPS on
+`URL_SHORTENER_ADDR` and does not bind a plain-HTTP redirect listener
+(callers are expected to use `https://` URLs); a connection to the
+HTTP scheme on the same port will fail at the TLS handshake. The
+underlying `crypto/tls` defaults apply (TLS 1.2 minimum, modern
+cipher suites, HTTP/2 enabled).
+
+For local development, the [`just dev-certs`](Justfile) recipe
+generates a host-trusted cert + key under `dev/certs/` (gitignored)
+via [mkcert](https://github.com/FiloSottile/mkcert). The first run
+also installs mkcert's root CA into the host trust stores so
+browsers and `curl` accept the cert without `-k`. Then either run
+the binary directly:
+
+```sh
+just dev-certs
+URL_SHORTENER_TLS_CERT_FILE=dev/certs/cert.pem \
+URL_SHORTENER_TLS_KEY_FILE=dev/certs/key.pem \
+URL_SHORTENER_ADDR=:8443 \
+URL_SHORTENER_BASE_URL=https://localhost:8443 \
+URL_SHORTENER_DATABASE_URL=postgres://... \
+URL_SHORTENER_REDIS_URL=redis://... \
+./bin/url-shortener run
+```
+
+or use the `tls` compose profile, which mounts `./dev/certs/` into a
+distroless container and exposes the app on `:8443`:
+
+```sh
+just dev-certs                                  # one-time per host
+docker compose --profile=tls up --wait -d
+curl https://localhost:8443/healthz             # {"status":"ok"}
+docker compose --profile=tls down -v
+```
+
+The `tls` profile shares the `db` and `redis` services with `dev` (it
+just swaps `server` for `server-tls`), so the two profiles must not
+run simultaneously -- they bind the same Postgres / Redis host ports.
+
+### Reverse-proxy deployment (Caddy)
+
+For production, the more common pattern is to terminate TLS on a
+reverse proxy and forward plain HTTP to the app on a private network.
+The proxy handles the certificate lifecycle (ACME, OCSP, renewal),
+the app stays focused on its own concerns, and the same image works
+behind any proxy choice.
+
+Two pieces are needed on the app side:
+
+1. Leave `URL_SHORTENER_TLS_CERT_FILE` / `URL_SHORTENER_TLS_KEY_FILE`
+   unset so the server stays on plain HTTP.
+2. Set `URL_SHORTENER_TRUSTED_PROXIES` to the CIDR(s) the proxy
+   reaches the app from. The server then walks `X-Forwarded-For`
+   from those peers to recover the real client IP (used by the
+   request log's `remote_ip` field and by `c.RealIP()` everywhere).
+   `X-Forwarded-For` from peers outside the list is ignored, which
+   prevents header spoofing from any client that can talk directly
+   to the app.
+
+Minimal Caddyfile mirroring the `dev` compose stack:
+
+```caddyfile
+example.com {
+    # Caddy obtains and renews the cert from Let's Encrypt
+    # automatically on the first request to :443.
+    reverse_proxy 127.0.0.1:8080 {
+        # Caddy adds X-Forwarded-For / X-Forwarded-Proto / X-Forwarded-Host
+        # to the upstream request by default; no extra header_up
+        # block is needed.
+    }
+}
+```
+
+App-side env to match (Caddy on the same host, talking to the app
+over the loopback interface):
+
+```sh
+URL_SHORTENER_ADDR=:8080
+URL_SHORTENER_BASE_URL=https://example.com
+URL_SHORTENER_TRUSTED_PROXIES=127.0.0.1/32,::1/128
+```
+
+If Caddy runs in a different container on a Docker bridge network,
+swap the loopback CIDR for the bridge subnet (e.g.
+`172.16.0.0/12,127.0.0.1/32` covers the default Docker IP ranges).
+For Kubernetes, set it to the cluster's pod-CIDR plus the node-CIDR
+the ingress controller forwards from.
+
+The same shape works for nginx (`proxy_set_header X-Forwarded-For
+$proxy_add_x_forwarded_for;`) and Traefik (XFF set automatically).
+What matters on the app side is the `URL_SHORTENER_TRUSTED_PROXIES`
+list -- the proxy choice is otherwise opaque.
 
 ## Layout (target)
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,12 +22,28 @@
 #       Bring up:  docker compose --profile=test up --wait -d
 #       Tear down: docker compose --profile=test down -v
 #
-# Every service belongs to exactly one profile, so a bare
-# `docker compose up` starts nothing. That's intentional: the previous
-# arrangement (default services + a test profile) had compose start the
-# default services *in addition to* test ones whenever `--profile=test`
-# was passed, because no-profile services run for every invocation.
-# Forcing both profiles to be opt-in eliminates that accidental overlap.
+#   `tls` profile  -- `db`, `redis`, `server-tls`
+#     Mirrors `dev` but the binary speaks HTTPS on :8443 using a static
+#     cert + key mounted from `./dev/certs/` (generate them once with
+#     `just dev-certs`, gitignored). `db` and `redis` are reused via
+#     multi-profile membership; the `tls` profile also exposes them on
+#     the same standard host ports as `dev` so the two profiles must
+#     not be running simultaneously.
+#
+#       Prereq:    just dev-certs        (one-time per host)
+#       Bring up:  docker compose --profile=tls up --wait -d
+#       Tear down: docker compose --profile=tls down -v
+#       Test:      curl https://localhost:8443/healthz
+#
+# Every service is profile-gated, so a bare `docker compose up` starts
+# nothing. That's intentional: the previous arrangement (default
+# services + a test profile) had compose start the default services
+# *in addition to* test ones whenever `--profile=test` was passed,
+# because no-profile services run for every invocation. Forcing every
+# profile to be opt-in eliminates that accidental overlap.
+# `db` and `redis` are members of both `dev` and `tls` so the two
+# profiles share the same data store; only one can run at a time
+# because they bind the same host ports (5432 / 6379).
 
 name: url-shortener
 
@@ -68,7 +84,7 @@ services:
 
   db:
     <<: *postgres-base
-    profiles: ["dev"]
+    profiles: ["dev", "tls"]
     # Postgres 18+ expects a single mount at /var/lib/postgresql; the actual
     # data dir lives in a versioned subdirectory inside it (e.g. 18/docker).
     volumes:
@@ -78,7 +94,7 @@ services:
 
   redis:
     <<: *redis-base
-    profiles: ["dev"]
+    profiles: ["dev", "tls"]
     volumes:
       - redis_data:/data
     ports:
@@ -118,6 +134,55 @@ services:
     # started").
     healthcheck:
       test: ["CMD", "/usr/local/bin/url-shortener", "healthcheck"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  # --- `tls` profile --------------------------------------------------------
+  # Same binary as `server`, but speaks HTTPS on :8443 using the cert +
+  # key in ./dev/certs/ (run `just dev-certs` to generate them; both
+  # files are gitignored). The compose volume is read-only so an
+  # accidental rotation in the running container can't truncate the
+  # PEM files on the host.
+
+  server-tls:
+    profiles: ["tls"]
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        VERSION: dev
+        COMMIT: dev
+    command: ["run"]
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      URL_SHORTENER_ADDR: ":8443"
+      URL_SHORTENER_ENV: dev
+      URL_SHORTENER_LOG_LEVEL: debug
+      URL_SHORTENER_LOG_FORMAT: text
+      URL_SHORTENER_DATABASE_URL: postgres://postgres:postgres@db:5432/url_shortener?sslmode=disable
+      URL_SHORTENER_REDIS_URL: redis://redis:6379/0
+      URL_SHORTENER_BASE_URL: https://localhost:8443
+      URL_SHORTENER_AUTO_MIGRATE: "true"
+      URL_SHORTENER_TLS_CERT_FILE: /etc/url-shortener/certs/cert.pem
+      URL_SHORTENER_TLS_KEY_FILE: /etc/url-shortener/certs/key.pem
+    volumes:
+      - ./dev/certs:/etc/url-shortener/certs:ro
+    ports:
+      - "8443:8443"
+    # `--insecure` because the in-container loopback hop probes
+    # https://127.0.0.1, which the mkcert-issued cert doesn't claim
+    # (it's signed for localhost / 127.0.0.1 from the host's perspective
+    # but the cert verifier inside the container has no view of the
+    # host's local CA trust). The probe is a liveness check, not a
+    # security boundary.
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/url-shortener", "healthcheck", "--url=https://127.0.0.1:8443/healthz", "--insecure"]
       interval: 5s
       timeout: 3s
       retries: 10

--- a/compose.yaml
+++ b/compose.yaml
@@ -171,8 +171,12 @@ services:
       URL_SHORTENER_AUTO_MIGRATE: "true"
       URL_SHORTENER_TLS_CERT_FILE: /etc/url-shortener/certs/cert.pem
       URL_SHORTENER_TLS_KEY_FILE: /etc/url-shortener/certs/key.pem
+    # Cert source defaults to ./dev/certs (the dir `just dev-certs`
+    # writes to). The `just tls-smoke` recipe overrides this with
+    # TLS_CERTS_DIR pointing at an isolated tempdir so the smoke run
+    # never clobbers a developer's host-trusted dev certs.
     volumes:
-      - ./dev/certs:/etc/url-shortener/certs:ro
+      - ${TLS_CERTS_DIR:-./dev/certs}:/etc/url-shortener/certs:ro
     ports:
       - "8443:8443"
     # `--insecure` because the in-container loopback hop probes

--- a/dev/certs/.gitignore
+++ b/dev/certs/.gitignore
@@ -1,0 +1,3 @@
+# mkcert-generated dev certs (host-trusted, but never committed --
+# every contributor regenerates locally with `just dev-certs`).
+*.pem

--- a/internal/cli/healthcheck.go
+++ b/internal/cli/healthcheck.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"time"
@@ -16,10 +17,16 @@ import (
 //
 //	healthcheck:
 //	  test: ["CMD", "/usr/local/bin/url-shortener", "healthcheck"]
+//
+// For TLS-fronted services (the `tls` compose profile), pass
+// `--url=https://127.0.0.1:8443/healthz --insecure` so the probe
+// skips cert verification -- the certificate is intended for the
+// outside world, not the in-container loopback hop.
 func newHealthcheckCmd() *cobra.Command {
 	var (
-		url     string
-		timeout time.Duration
+		url      string
+		timeout  time.Duration
+		insecure bool
 	)
 	cmd := &cobra.Command{
 		Use:   "healthcheck",
@@ -32,7 +39,20 @@ func newHealthcheckCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			resp, err := http.DefaultClient.Do(req)
+			client := http.DefaultClient
+			if insecure {
+				// New client per call so we don't mutate
+				// http.DefaultTransport. The probe is short-lived
+				// and runs once per healthcheck invocation, so the
+				// allocation cost is irrelevant.
+				client = &http.Client{
+					Transport: &http.Transport{
+						TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // intentional for in-container loopback probe
+					},
+					Timeout: timeout,
+				}
+			}
+			resp, err := client.Do(req)
 			if err != nil {
 				return err
 			}
@@ -46,5 +66,6 @@ func newHealthcheckCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&url, "url", "http://127.0.0.1:8080/healthz", "URL to probe")
 	cmd.Flags().DurationVar(&timeout, "timeout", 2*time.Second, "request timeout")
+	cmd.Flags().BoolVar(&insecure, "insecure", false, "skip TLS certificate verification (use with https:// URLs in compose healthchecks)")
 	return cmd
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,7 +7,9 @@ package config
 
 import (
 	"fmt"
+	"net"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -70,6 +72,25 @@ type Config struct {
 	DBMaxConnLifetime   time.Duration `mapstructure:"db_max_conn_lifetime"   json:"db_max_conn_lifetime"`
 	DBMaxConnIdleTime   time.Duration `mapstructure:"db_max_conn_idle_time"  json:"db_max_conn_idle_time"`
 	DBHealthCheckPeriod time.Duration `mapstructure:"db_health_check_period" json:"db_health_check_period"`
+
+	// TLSCertFile and TLSKeyFile, when both non-empty, switch the HTTP
+	// server to HTTPS on Addr using the PEM-encoded certificate and
+	// private key at the given paths. Both must be set together --
+	// Validate rejects half-configured pairs. Empty (the default) keeps
+	// the server on plain HTTP, which is the right choice when fronted
+	// by a TLS-terminating reverse proxy (Caddy/nginx/Traefik).
+	TLSCertFile string `mapstructure:"tls_cert_file" json:"tls_cert_file"`
+	TLSKeyFile  string `mapstructure:"tls_key_file"  json:"tls_key_file"`
+
+	// TrustedProxies is a comma-separated list of CIDR blocks (parsed by
+	// net.ParseCIDR) whose request peers are trusted to forward client
+	// IP addresses via X-Forwarded-For. When a request's RemoteAddr
+	// falls inside one of these ranges, the server walks XFF to find
+	// the original client IP; otherwise XFF is ignored and RemoteAddr
+	// stands. Empty (the default) leaves Echo's IPExtractor unset --
+	// equivalent to "no proxy in front". Set this to e.g.
+	// `127.0.0.1/32,10.0.0.0/8` when running behind a reverse proxy.
+	TrustedProxies []string `mapstructure:"trusted_proxies" json:"trusted_proxies"`
 }
 
 // Load reads the configuration from environment variables and applies the
@@ -89,6 +110,7 @@ func Load() (Config, error) {
 		"db_max_conns", "db_min_conns",
 		"db_max_conn_lifetime", "db_max_conn_idle_time",
 		"db_health_check_period",
+		"tls_cert_file", "tls_key_file", "trusted_proxies",
 	} {
 		_ = v.BindEnv(key)
 	}
@@ -183,6 +205,39 @@ func (c Config) Validate() error {
 	if c.DBHealthCheckPeriod < 0 {
 		return fmt.Errorf("config: db_health_check_period must be >= 0")
 	}
+
+	// TLS cert + key are paired -- one without the other is almost
+	// always a misconfiguration (e.g. a Helm values typo) and we'd
+	// rather refuse to start than silently fall back to plain HTTP
+	// when the operator thought TLS was on.
+	if (c.TLSCertFile == "") != (c.TLSKeyFile == "") {
+		return fmt.Errorf("config: tls_cert_file and tls_key_file must be set together")
+	}
+	if c.TLSCertFile != "" {
+		// Stat both files at startup so missing-file errors surface as
+		// a config validation failure (clear stderr line, exit 1)
+		// rather than as the first request hitting a nil TLS config
+		// many seconds into the run.
+		if _, err := os.Stat(c.TLSCertFile); err != nil {
+			return fmt.Errorf("config: tls_cert_file: %w", err)
+		}
+		if _, err := os.Stat(c.TLSKeyFile); err != nil {
+			return fmt.Errorf("config: tls_key_file: %w", err)
+		}
+	}
+
+	// Each TrustedProxies entry must be a valid CIDR. Empty strings
+	// (which can sneak in via stray commas like "127.0.0.1/32,") are
+	// silently skipped on the consuming side, so don't error here.
+	for _, cidr := range c.TrustedProxies {
+		if cidr == "" {
+			continue
+		}
+		if _, _, err := net.ParseCIDR(cidr); err != nil {
+			return fmt.Errorf("config: trusted_proxies entry %q: %w", cidr, err)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,8 @@ package config_test
 
 import (
 	"os"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -81,7 +83,7 @@ func TestLoad_EnvOverrides(t *testing.T) {
 		AutoMigrate: true,
 		CodeLength:  9,
 	}
-	if cfg != want {
+	if !reflect.DeepEqual(cfg, want) {
 		t.Errorf("cfg = %+v\nwant %+v", cfg, want)
 	}
 }
@@ -205,6 +207,141 @@ func TestRedacted_StripsPasswords(t *testing.T) {
 	if !strings.Contains(cfg.DatabaseURL, "secret") {
 		t.Error("Redacted() must not mutate the receiver")
 	}
+}
+
+func TestLoad_TLSAndTrustedProxiesEnvOverrides(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("URL_SHORTENER_DATABASE_URL", "postgres://u:p@h:5432/db")
+	t.Setenv("URL_SHORTENER_REDIS_URL", "redis://localhost:6379/0")
+	// Files must exist for Validate's stat check to pass; create
+	// scratch files with arbitrary content (Validate doesn't try to
+	// parse the PEM, only Stat the path).
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(certPath, []byte("not a real cert"), 0o600); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	if err := os.WriteFile(keyPath, []byte("not a real key"), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	t.Setenv("URL_SHORTENER_TLS_CERT_FILE", certPath)
+	t.Setenv("URL_SHORTENER_TLS_KEY_FILE", keyPath)
+	// Comma-separated CIDR list -- viper's default decode hooks split
+	// strings on commas when targeting a []string field.
+	t.Setenv("URL_SHORTENER_TRUSTED_PROXIES", "127.0.0.1/32,10.0.0.0/8")
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load(): %v", err)
+	}
+
+	if cfg.TLSCertFile != certPath {
+		t.Errorf("TLSCertFile = %q, want %q", cfg.TLSCertFile, certPath)
+	}
+	if cfg.TLSKeyFile != keyPath {
+		t.Errorf("TLSKeyFile = %q, want %q", cfg.TLSKeyFile, keyPath)
+	}
+	wantProxies := []string{"127.0.0.1/32", "10.0.0.0/8"}
+	if !reflect.DeepEqual(cfg.TrustedProxies, wantProxies) {
+		t.Errorf("TrustedProxies = %v, want %v", cfg.TrustedProxies, wantProxies)
+	}
+}
+
+func TestValidate_TLSAndTrustedProxies(t *testing.T) {
+	t.Parallel()
+
+	const (
+		redisURL    = "redis://localhost:6379/0"
+		databaseURL = "postgres://u:p@h:5432/db"
+	)
+	// realDir + realCert/realKey are paths that exist, used by the
+	// happy-path subtests. Each subtest gets its own t.TempDir to
+	// keep them parallel-safe.
+	base := func(t *testing.T) (config.Config, string, string) {
+		t.Helper()
+		dir := t.TempDir()
+		certPath := filepath.Join(dir, "cert.pem")
+		keyPath := filepath.Join(dir, "key.pem")
+		if err := os.WriteFile(certPath, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write cert: %v", err)
+		}
+		if err := os.WriteFile(keyPath, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write key: %v", err)
+		}
+		return config.Config{
+			Env: "prod", Addr: ":8080", BaseURL: "http://x",
+			LogLevel: "info", LogFormat: "json",
+			DatabaseURL: databaseURL, RedisURL: redisURL,
+		}, certPath, keyPath
+	}
+
+	t.Run("cert without key is rejected", func(t *testing.T) {
+		t.Parallel()
+		c, certPath, _ := base(t)
+		c.TLSCertFile = certPath
+		if err := c.Validate(); err == nil {
+			t.Error("Validate() returned nil; want error for unpaired cert")
+		}
+	})
+
+	t.Run("key without cert is rejected", func(t *testing.T) {
+		t.Parallel()
+		c, _, keyPath := base(t)
+		c.TLSKeyFile = keyPath
+		if err := c.Validate(); err == nil {
+			t.Error("Validate() returned nil; want error for unpaired key")
+		}
+	})
+
+	t.Run("missing cert file is rejected", func(t *testing.T) {
+		t.Parallel()
+		c, _, keyPath := base(t)
+		c.TLSCertFile = filepath.Join(t.TempDir(), "nope.pem")
+		c.TLSKeyFile = keyPath
+		if err := c.Validate(); err == nil {
+			t.Error("Validate() returned nil; want error for missing cert path")
+		}
+	})
+
+	t.Run("both files set and present passes", func(t *testing.T) {
+		t.Parallel()
+		c, certPath, keyPath := base(t)
+		c.TLSCertFile = certPath
+		c.TLSKeyFile = keyPath
+		if err := c.Validate(); err != nil {
+			t.Errorf("Validate() = %v; want nil", err)
+		}
+	})
+
+	t.Run("invalid CIDR is rejected", func(t *testing.T) {
+		t.Parallel()
+		c, _, _ := base(t)
+		c.TrustedProxies = []string{"not-a-cidr"}
+		if err := c.Validate(); err == nil {
+			t.Error("Validate() returned nil; want error for bad CIDR")
+		}
+	})
+
+	t.Run("multiple valid CIDRs pass", func(t *testing.T) {
+		t.Parallel()
+		c, _, _ := base(t)
+		c.TrustedProxies = []string{"127.0.0.1/32", "10.0.0.0/8", "::1/128"}
+		if err := c.Validate(); err != nil {
+			t.Errorf("Validate() = %v; want nil", err)
+		}
+	})
+
+	t.Run("empty entries are skipped", func(t *testing.T) {
+		t.Parallel()
+		c, _, _ := base(t)
+		// Stray comma in env var produces an empty entry; should not
+		// fail validation since the consumer ignores empties too.
+		c.TrustedProxies = []string{"127.0.0.1/32", ""}
+		if err := c.Validate(); err != nil {
+			t.Errorf("Validate() = %v; want nil", err)
+		}
+	})
 }
 
 // clearEnv unsets every URL_SHORTENER_* env var for the duration of the test

--- a/internal/server/proxy.go
+++ b/internal/server/proxy.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"net"
+
+	"github.com/labstack/echo/v5"
+)
+
+// buildIPExtractor returns an IPExtractor configured to walk
+// X-Forwarded-For only when the request's immediate peer falls inside
+// one of the supplied CIDR ranges. It returns nil when the slice is
+// empty (or contains only empty strings) so the caller can fall back
+// to Echo's default RemoteAddr-based behavior -- callers should not
+// install a nil extractor.
+//
+// CIDR strings are expected to have already been validated by
+// config.Validate; entries that fail to parse here are silently
+// skipped to keep the function total. (Validate runs at startup, so
+// reaching here with an unparseable entry would mean the validator
+// has a bug -- worth the small belt-and-suspenders.)
+func buildIPExtractor(trustedProxies []string) echo.IPExtractor {
+	opts := make([]echo.TrustOption, 0, len(trustedProxies))
+	for _, cidr := range trustedProxies {
+		if cidr == "" {
+			continue
+		}
+		_, ipnet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			continue
+		}
+		opts = append(opts, echo.TrustIPRange(ipnet))
+	}
+	if len(opts) == 0 {
+		return nil
+	}
+	return echo.ExtractIPFromXFFHeader(opts...)
+}

--- a/internal/server/proxy_test.go
+++ b/internal/server/proxy_test.go
@@ -1,0 +1,101 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestBuildIPExtractor exercises the pure CIDR-matching logic so the
+// proxy-aware path is covered without needing a real Postgres + Redis
+// (i.e. without the `integration` build tag).
+//
+// The IPExtractor returned by buildIPExtractor takes an *http.Request and
+// walks X-Forwarded-For only if the immediate RemoteAddr peer falls
+// inside one of the trusted CIDR ranges. The matrix below verifies the
+// four interesting combinations: trusted+XFF, trusted+no-XFF,
+// untrusted+XFF (must ignore XFF), and the empty-list base case (no
+// extractor returned).
+func TestBuildIPExtractor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty list returns nil", func(t *testing.T) {
+		t.Parallel()
+		if got := buildIPExtractor(nil); got != nil {
+			t.Errorf("buildIPExtractor(nil) = non-nil, want nil")
+		}
+		if got := buildIPExtractor([]string{}); got != nil {
+			t.Errorf("buildIPExtractor([]string{}) = non-nil, want nil")
+		}
+		if got := buildIPExtractor([]string{""}); got != nil {
+			t.Errorf("buildIPExtractor([]) of empty strings = non-nil, want nil")
+		}
+	})
+
+	t.Run("invalid CIDR is silently dropped", func(t *testing.T) {
+		t.Parallel()
+		// Valid + invalid mix: extractor still installed, only valid
+		// entry is honored. Defense in depth -- config.Validate already
+		// guards against bad CIDRs reaching here.
+		ext := buildIPExtractor([]string{"not-a-cidr", "127.0.0.1/32"})
+		if ext == nil {
+			t.Fatal("extractor = nil, want non-nil with one valid entry")
+		}
+	})
+
+	t.Run("XFF honored iff RemoteAddr in trusted CIDR", func(t *testing.T) {
+		t.Parallel()
+		ext := buildIPExtractor([]string{"127.0.0.0/8", "10.0.0.0/8"})
+		if ext == nil {
+			t.Fatal("extractor = nil, want non-nil")
+		}
+
+		cases := []struct {
+			name       string
+			remoteAddr string
+			xff        string
+			want       string
+		}{
+			{
+				name:       "trusted peer + XFF -> client from XFF",
+				remoteAddr: "127.0.0.1:54321",
+				xff:        "203.0.113.42",
+				want:       "203.0.113.42",
+			},
+			{
+				name:       "trusted peer + multi-hop XFF -> first untrusted from left",
+				remoteAddr: "10.0.0.5:54321",
+				xff:        "203.0.113.42, 10.0.0.7",
+				want:       "203.0.113.42",
+			},
+			{
+				name:       "trusted peer + no XFF -> RemoteAddr",
+				remoteAddr: "127.0.0.1:54321",
+				xff:        "",
+				want:       "127.0.0.1",
+			},
+			{
+				name:       "untrusted peer + spoofed XFF -> RemoteAddr (XFF ignored)",
+				remoteAddr: "198.51.100.7:54321",
+				xff:        "203.0.113.42",
+				want:       "198.51.100.7",
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				req.RemoteAddr = tc.remoteAddr
+				if tc.xff != "" {
+					req.Header.Set("X-Forwarded-For", tc.xff)
+				}
+				got := ext(req)
+				if got != tc.want {
+					t.Errorf("extractor(remote=%q, xff=%q) = %q, want %q",
+						tc.remoteAddr, tc.xff, got, tc.want)
+				}
+			})
+		}
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -85,6 +85,20 @@ func New(cfg config.Config, logger *slog.Logger, deps Deps) *Server {
 	}
 
 	e := echo.New()
+
+	// IPExtractor is consulted by Context.RealIP() and by the request
+	// logger's LogRemoteIP path. With cfg.TrustedProxies empty (the
+	// default), we leave IPExtractor unset so Echo falls back to its
+	// legacy RemoteAddr-based behavior -- equivalent to "no proxy in
+	// front", which is correct for direct deployments and for the
+	// docker compose stack today. When CIDRs are configured, install
+	// an XFF-aware extractor that only honors the header when the
+	// immediate peer falls inside one of those ranges; spoofed XFF
+	// from untrusted clients is ignored.
+	if extractor := buildIPExtractor(cfg.TrustedProxies); extractor != nil {
+		e.IPExtractor = extractor
+	}
+
 	e.Use(middleware.Recover())
 	e.Use(middleware.RequestID())
 	e.Use(slogRequestLogger(logger))
@@ -159,11 +173,31 @@ func (s *Server) Run(ctx context.Context) error {
 // Serve runs the HTTP server using the provided already-bound listener. It
 // blocks until ctx is canceled and then shuts down gracefully. Tests use
 // this with a port-0 listener so they can pick up the bound address.
+//
+// When cfg.TLSCertFile and cfg.TLSKeyFile are both set, the server speaks
+// HTTPS on the listener; otherwise it speaks plain HTTP. The TLS path
+// uses http.Server.ServeTLS, which loads the cert+key on each call;
+// config.Validate already stat'd both paths at startup so a bad path
+// would have failed earlier with a clear error.
 func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
 	errCh := make(chan error, 1)
+	tlsEnabled := s.cfg.TLSCertFile != "" && s.cfg.TLSKeyFile != ""
 	go func() {
-		s.logger.Info("http server starting", "addr", ln.Addr().String())
-		if err := s.http.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		s.logger.Info("http server starting",
+			"addr", ln.Addr().String(),
+			"tls", tlsEnabled,
+		)
+		var err error
+		if tlsEnabled {
+			// ServeTLS reads cert+key from disk on every call. The
+			// http.Server.TLSConfig is left at its zero value so Go's
+			// secure defaults apply (TLS 1.2+ minimum from Go 1.18,
+			// modern cipher suites with HTTP/2 support).
+			err = s.http.ServeTLS(ln, s.cfg.TLSCertFile, s.cfg.TLSKeyFile)
+		} else {
+			err = s.http.Serve(ln)
+		}
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errCh <- err
 		}
 		close(errCh)
@@ -233,6 +267,7 @@ func slogRequestLogger(logger *slog.Logger) echo.MiddlewareFunc {
 		LogMethod:    true,
 		LogLatency:   true,
 		LogRequestID: true,
+		LogRemoteIP:  true,
 		HandleError:  true,
 		LogValuesFunc: func(c *echo.Context, v middleware.RequestLoggerValues) error {
 			level := slog.LevelInfo
@@ -249,6 +284,7 @@ func slogRequestLogger(logger *slog.Logger) echo.MiddlewareFunc {
 				"status", v.Status,
 				"latency_ms", v.Latency.Milliseconds(),
 				"request_id", v.RequestID,
+				"remote_ip", v.RemoteIP,
 			}
 			if v.Error != nil {
 				attrs = append(attrs, "error", v.Error.Error())

--- a/internal/server/tls_integration_test.go
+++ b/internal/server/tls_integration_test.go
@@ -1,0 +1,218 @@
+//go:build integration
+
+// End-to-end TLS smoke test: generates a self-signed cert at test time,
+// brings up the full server with cfg.TLSCertFile + cfg.TLSKeyFile set,
+// hits /healthz over HTTPS, and verifies the handshake + response work.
+//
+// This exercises the cfg.TLSCertFile branch of server.Serve without
+// requiring any cert material to be checked into the repo. Requires
+// real Postgres + Redis (URL_SHORTENER_TEST_*), same as the other
+// integration tests.
+
+package server_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"log/slog"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/vancanhuit/url-shortener/internal/cache"
+	"github.com/vancanhuit/url-shortener/internal/config"
+	"github.com/vancanhuit/url-shortener/internal/server"
+	"github.com/vancanhuit/url-shortener/internal/shortener"
+	"github.com/vancanhuit/url-shortener/internal/store"
+)
+
+// generateSelfSignedCert writes a self-signed P-256 ECDSA certificate
+// for 127.0.0.1 + ::1 + localhost into dir as cert.pem / key.pem and
+// returns those two paths. The cert is valid for one hour, which is
+// effectively forever for a single test run.
+func generateSelfSignedCert(t *testing.T, dir string) (certPath, keyPath string) {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa.GenerateKey: %v", err)
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("rand serial: %v", err)
+	}
+	tmpl := x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "url-shortener-test"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		DNSNames:     []string{"localhost"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("x509.CreateCertificate: %v", err)
+	}
+
+	certPath = filepath.Join(dir, "cert.pem")
+	certFile, err := os.Create(certPath)
+	if err != nil {
+		t.Fatalf("create cert.pem: %v", err)
+	}
+	if err := pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: der}); err != nil {
+		t.Fatalf("pem encode cert: %v", err)
+	}
+	if err := certFile.Close(); err != nil {
+		t.Fatalf("close cert.pem: %v", err)
+	}
+
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatalf("MarshalECPrivateKey: %v", err)
+	}
+	keyPath = filepath.Join(dir, "key.pem")
+	keyFile, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatalf("create key.pem: %v", err)
+	}
+	if err := pem.Encode(keyFile, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}); err != nil {
+		t.Fatalf("pem encode key: %v", err)
+	}
+	if err := keyFile.Close(); err != nil {
+		t.Fatalf("close key.pem: %v", err)
+	}
+	return certPath, keyPath
+}
+
+func TestServer_TLSListenerServesHTTPS(t *testing.T) {
+	dbURL := os.Getenv("URL_SHORTENER_TEST_DATABASE_URL")
+	redisURL := os.Getenv("URL_SHORTENER_TEST_REDIS_URL")
+	if dbURL == "" || redisURL == "" {
+		t.Skip("URL_SHORTENER_TEST_DATABASE_URL / URL_SHORTENER_TEST_REDIS_URL not set; skipping integration test")
+	}
+
+	certPath, keyPath := generateSelfSignedCert(t, t.TempDir())
+
+	ctx := t.Context()
+	st, err := store.New(ctx, dbURL)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(st.Close)
+	cc, err := cache.New(ctx, redisURL)
+	if err != nil {
+		t.Fatalf("cache.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cc.Close() })
+	gen, err := shortener.NewGenerator(shortener.DefaultLength)
+	if err != nil {
+		t.Fatalf("shortener.NewGenerator: %v", err)
+	}
+
+	cfg := config.Config{
+		Env:         config.EnvDev,
+		Addr:        "127.0.0.1:0",
+		BaseURL:     "https://short.test",
+		LogLevel:    "info",
+		LogFormat:   "text",
+		CodeLength:  shortener.DefaultLength,
+		TLSCertFile: certPath,
+		TLSKeyFile:  keyPath,
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := server.New(cfg, logger, server.Deps{Store: st, Cache: cc, Generator: gen})
+
+	runCtx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve(runCtx, ln) }()
+
+	addr := "https://" + ln.Addr().String()
+
+	// Build a client that trusts the test cert by reading it back from
+	// disk and adding it to a fresh root pool. This is stricter than
+	// InsecureSkipVerify and means the test would catch a regression
+	// where ServeTLS served the wrong cert (e.g. a default fallback).
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("read cert.pem: %v", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(certPEM) {
+		t.Fatal("AppendCertsFromPEM returned false; cert.pem unusable")
+	}
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12},
+		},
+		Timeout: 5 * time.Second,
+	}
+
+	// Poll /healthz until the server is up. The server starts the
+	// listener synchronously inside Serve's goroutine but TLS adds a
+	// handshake on top, so the first few attempts may race.
+	deadline := time.Now().Add(5 * time.Second)
+	var resp *http.Response
+	for time.Now().Before(deadline) {
+		resp, err = client.Get(addr + "/healthz")
+		if err == nil && resp.StatusCode == http.StatusOK {
+			break
+		}
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("GET %s/healthz over HTTPS: %v", addr, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+
+	// Negative check: a plain-HTTP request to a TLS listener triggers
+	// Go's stdlib "client sent an HTTP request to an HTTPS server"
+	// canned response, served as 400 Bad Request from inside the TLS
+	// state machine. We can't assert err != nil (the response *is*
+	// successful at the HTTP level), but the 400 status -- distinct
+	// from the 200 we'd see if a plain-HTTP server were also on the
+	// listener -- proves the TLS branch was the only one mounted.
+	plainResp, plainErr := http.Get("http://" + ln.Addr().String() + "/healthz")
+	if plainErr != nil {
+		t.Logf("plain-HTTP-to-TLS request errored (also acceptable): %v", plainErr)
+	} else {
+		defer func() { _ = plainResp.Body.Close() }()
+		if plainResp.StatusCode == http.StatusOK {
+			t.Errorf("plain-HTTP request to TLS port returned 200; expected 400 or connection error")
+		}
+	}
+
+	cancel()
+	select {
+	case serveErr := <-done:
+		if serveErr != nil {
+			t.Errorf("Serve returned error: %v", serveErr)
+		}
+	case <-time.After(20 * time.Second):
+		t.Error("Serve did not return within 20s of cancellation")
+	}
+}


### PR DESCRIPTION
Two new operational capabilities, both env-var driven (no CLI flags -- matches the existing `URL_SHORTENER_*` configuration surface) and both opt-in (zero behavior change when the new env vars are unset).

Direct TLS on the binary
========================

`URL_SHORTENER_TLS_CERT_FILE` + `URL_SHORTENER_TLS_KEY_FILE`, both required-together (a half-configured pair is a startup error rather than a silent fall back to plain HTTP). When set, `server.Serve` calls `http.Server.ServeTLS(ln, certFile, keyFile)` instead of `http.Server.Serve(ln)`. `crypto/tls` defaults apply: TLS 1.2 minimum, modern cipher suites, HTTP/2 enabled.

`config.Validate` stats both files at startup so a bad path surfaces as a clear stderr line + exit 1 rather than as the first request hitting a nil TLS config many seconds into the run.

The release binaries already shipped with `crypto/tls` baked in; this only flips the `Serve` branch.

Proxy-aware request handling
============================

`URL_SHORTENER_TRUSTED_PROXIES`: comma-separated CIDR list (e.g. `127.0.0.1/32,10.0.0.0/8`). When non-empty, `server.New` installs an `echo.IPExtractor` built from `echo.ExtractIPFromXFFHeader` + `echo.TrustIPRange(...)` for each CIDR. The extractor walks `X-Forwarded-For` only when the request's immediate `RemoteAddr` peer falls inside one of the trusted ranges; XFF from peers outside the list is ignored. This is the standard secure pattern -- prevents header spoofing from any client that can talk directly to the app.

Empty list (the default) leaves `e.IPExtractor` unset so Echo falls back to its legacy `RemoteAddr`-based behavior. Existing direct- deployment installs see no change.

`slogRequestLogger` now sets `LogRemoteIP: true` and emits `remote_ip=...` on every request log line, so behind-a-proxy deployments get the real client IP in the structured logs (not the proxy's address).

`buildIPExtractor` is its own file (`internal/server/proxy.go`) and covered by a pure unit test (`proxy_test.go`, no integration build tag) that verifies the four interesting combinations: trusted + XFF, trusted + multi-hop XFF, trusted + no XFF, untrusted + spoofed XFF.

Healthcheck
===========

`url-shortener healthcheck` gains a `--insecure` flag that skips TLS certificate verification. The compose `tls` profile uses it because the in-container loopback probe (`https://127.0.0.1:8443`) can't validate the mkcert-issued cert through the container's limited trust store. The probe is a liveness check, not a security boundary, so skipping verification is fine here.

mkcert + dev/certs/
===================

`just dev-certs` calls mkcert to generate a host-trusted cert + key under `dev/certs/` (gitignored, every contributor regenerates locally). The cert is valid for `localhost` / `127.0.0.1` / `::1`, covering both binary-direct local runs and the compose `tls` profile. The first run also installs mkcert's local CA into the host trust stores so browsers and `curl` accept the cert without `-k`. The recipe `chmod 0644`s the key after generation because the distroless container's nonroot UID can't read mkcert's default 0600 file through a bind mount -- this is dev-only material, gitignored, never production.

Compose `tls` profile
=====================

New `server-tls` service: same Dockerfile build as `server`, but sets `URL_SHORTENER_ADDR=:8443` plus the two TLS env vars pointing at `/etc/url-shortener/certs/{cert,key}.pem`, mounts `./dev/certs` read-only into that path, exposes `:8443`, and uses `healthcheck --url=https://127.0.0.1:8443/healthz --insecure` for the docker healthcheck. `db` and `redis` join the `tls` profile so the data stack is shared with `dev`; the two profiles bind the same Postgres / Redis host ports so they must not run simultaneously.

Verified locally with `docker compose --profile=tls up --wait -d` + `curl https://localhost:8443/healthz` -- TLSv1.3 handshake, mkcert- signed cert accepted by the host's trust store, body `{"status":"ok"}`.

Reverse-proxy deployment (Caddy)
================================

Documented in the new "Deployment" README section as the production counterpart: leave `TLS_*` unset, set `TRUSTED_PROXIES` to the CIDR the proxy reaches the app from, let the proxy handle the cert lifecycle. Caddyfile snippet shows the minimal config for a same-host loopback deployment; notes cover Docker bridge networks and Kubernetes pod/node CIDRs as the two next-most-common cases.

Tests
=====

- `internal/config/config_test.go`:
  - `TestLoad_TLSAndTrustedProxiesEnvOverrides`: round-trips both new env vars through Viper (with comma-split CIDRs) and asserts the loaded `Config` matches.
  - `TestValidate_TLSAndTrustedProxies`: 7 subtests covering unpaired cert, unpaired key, missing-file cert, both-present happy path, invalid CIDR, multiple valid CIDRs (incl. IPv6), and stray-comma empty entries.
  - `TestLoad_EnvOverrides` switched from `cfg != want` to `reflect.DeepEqual` since `Config` now contains a slice field (Go forbids `==` on structs with slices).

- `internal/server/proxy_test.go`: pure unit test for `buildIPExtractor`, no integration build tag.

- `internal/server/tls_integration_test.go`: brings up the full server with a self-signed P-256 cert generated at test time (no PEM material checked in), hits `/healthz` over HTTPS with a client trusting only the test cert (stricter than `InsecureSkipVerify`: would catch a "served the wrong cert" regression), and verifies the negative path -- a plain-HTTP request to the TLS listener returns 400 (Go stdlib's "client sent an HTTP request to an HTTPS server" canned response), proving no plain-HTTP server is also bound.