### PR TITLE
feat(api): add `DELETE /api/v1/links/:code` with soft-delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,21 +184,32 @@ means "never expires". `click_count` is the lifetime hit count for
 the redirect endpoint, bumped fire-and-forget on each successful
 `/r/:code` so it never delays the 302.
 
-| Endpoint                  | Purpose                                                              |
-| ------------------------- | -------------------------------------------------------------------- |
-| `POST /api/v1/links`      | Create a link. Auto-generates a base62 code, or accepts a user one.  |
-| `GET  /api/v1/links/:code`| Fetch link metadata as JSON.                                         |
-| `GET  /r/:code`           | 302 redirect to the link's `target_url`. Read-through Redis cache.   |
+| Endpoint                    | Purpose                                                                                  |
+| --------------------------- | ---------------------------------------------------------------------------------------- |
+| `POST   /api/v1/links`      | Create a link. Auto-generates a base62 code, or accepts a user one.                      |
+| `GET    /api/v1/links/:code`| Fetch link metadata as JSON.                                                             |
+| `DELETE /api/v1/links/:code`| Soft-delete a link. Returns `204` on success, `404` thereafter; no body. See below.      |
+| `GET    /r/:code`           | 302 redirect to the link's `target_url`. Read-through Redis cache.                       |
 
 Validation: `target_url` must be `http`/`https`, have a host, and be at most
 2048 characters. User-supplied codes must match `[0-9A-Za-z]{4,64}`.
 `expires_at`, when supplied, must be in the future (a 30s grace window
 absorbs honest client/server clock skew). Status codes: `400` for
 malformed JSON, `409` for a duplicate user-supplied code, `422` for
-validation failures, `404` for unknown codes, `410 Gone` for an
-expired code (returned by both `GET /api/v1/links/:code` and
-`GET /r/:code` -- distinct from `404` so clients can tell a once-valid
-code from one that never existed).
+validation failures, `404` for unknown codes, `410 Gone` for a
+retired code (expired *or* soft-deleted; returned by both
+`GET /api/v1/links/:code` and `GET /r/:code` -- distinct from `404`
+so clients can tell a once-valid code from one that never existed).
+
+Soft-delete (`DELETE /api/v1/links/:code`) flips an internal
+`deleted_at` tombstone; the row stays in Postgres so audit columns
+(`created_at`, `click_count`, ...) survive. Subsequent
+`GET /r/:code` returns `410 Gone`, the cache entry is invalidated
+server-side, and the recent-links feed and dedup lookup both stop
+seeing the row. The first DELETE returns `204 No Content`; a second
+DELETE against the same code returns `404 not_found` -- the API is
+semantically idempotent (the row stays deleted) but distinguishes
+the two responses, mirroring how most REST APIs handle DELETE.
 
 Error responses carry a stable `code` field alongside the
 human-readable `error` so clients can branch on the failure without
@@ -215,6 +226,7 @@ parsing the message:
 | 409  | `code_taken`        | The user-supplied short code is already in use.           |
 | 404  | `not_found`         | The code does not exist (either malformed or unknown).    |
 | 410  | `link_expired`      | The link existed but its `expires_at` has passed.         |
+| 410  | `link_deleted`      | The link existed but was soft-deleted via `DELETE`.       |
 | 500  | `internal_error`    | Any other server-side failure; details are logged only.   |
 
 The string values are part of the public API contract and will not

--- a/internal/handlers/links.go
+++ b/internal/handlers/links.go
@@ -72,6 +72,7 @@ type LinkStore interface {
 	GetLinkByTargetURL(ctx context.Context, db store.DBTX, targetURL string) (store.Link, error)
 	ListLinks(ctx context.Context, db store.DBTX, limit int, beforeID int64) ([]store.Link, error)
 	IncrementClicks(ctx context.Context, db store.DBTX, code string) error
+	SoftDeleteLink(ctx context.Context, db store.DBTX, code string) error
 }
 
 // LinkCache is the cache surface the links handler depends on. It is
@@ -144,6 +145,7 @@ func NewLinks(cfg LinksConfig) *Links {
 func (h *Links) Mount(e *echo.Echo) {
 	e.POST("/api/v1/links", h.Create)
 	e.GET("/api/v1/links/:code", h.Get)
+	e.DELETE("/api/v1/links/:code", h.Delete)
 	e.GET("/r/:code", h.Redirect)
 }
 
@@ -190,6 +192,7 @@ const (
 	ErrCodeCodeTaken       = "code_taken"        // 409 when a user-supplied short code is already in use.
 	ErrCodeNotFound        = "not_found"         // 404 when the requested code does not exist.
 	ErrCodeLinkExpired     = "link_expired"      // 410 when the link existed but has passed its expires_at.
+	ErrCodeLinkDeleted     = "link_deleted"      // 410 when the link existed but was soft-deleted via DELETE /api/v1/links/:code.
 	ErrCodeInternal        = "internal_error"    // 500 for any other failure.
 )
 
@@ -425,10 +428,51 @@ func (h *Links) Get(c *echo.Context) error {
 		h.logger.Error("links: get failed", "error", err, "code", code)
 		return c.JSON(http.StatusInternalServerError, errResp(ErrCodeInternal, "internal error"))
 	}
+	if link.IsDeleted() {
+		return c.JSON(http.StatusGone, errResp(ErrCodeLinkDeleted, "link has been deleted"))
+	}
 	if link.IsExpired() {
 		return c.JSON(http.StatusGone, errResp(ErrCodeLinkExpired, "link has expired"))
 	}
 	return c.JSON(http.StatusOK, h.makeResp(link))
+}
+
+// Delete implements DELETE /api/v1/links/:code. It performs a
+// soft-delete: the row stays in `links` with its audit columns
+// intact, but `deleted_at` is stamped so the redirect, lookup, list,
+// and dedup paths all stop seeing it. The cache entry is invalidated
+// best-effort so a subsequent /r/:code goes to the store and surfaces
+// a 410.
+//
+// Idempotency is semantic, not response-shape: the first DELETE
+// against a live code returns 204; a second DELETE against the same
+// (now-deleted) code returns 404, the same response the API gives
+// for any other unknown / unreachable code. Clients that need to
+// treat both first-and-second-DELETE as success can collapse 204 +
+// 404 themselves.
+func (h *Links) Delete(c *echo.Context) error {
+	code := c.Param("code")
+	if !shortener.ValidCode(code) {
+		return c.JSON(http.StatusNotFound, errResp(ErrCodeNotFound, "not found"))
+	}
+	ctx := c.Request().Context()
+	err := h.store.SoftDeleteLink(ctx, nil, code)
+	if errors.Is(err, store.ErrNotFound) {
+		return c.JSON(http.StatusNotFound, errResp(ErrCodeNotFound, "not found"))
+	}
+	if err != nil {
+		h.logger.Error("links: delete failed", "error", err, "code", code)
+		return c.JSON(http.StatusInternalServerError, errResp(ErrCodeInternal, "internal error"))
+	}
+	// Best-effort cache invalidation: a stale entry would only
+	// last `cacheTTL` anyway, but eagerly removing it makes the
+	// post-delete /r/:code 410 immediately rather than after the
+	// TTL elapses. Failures are logged and otherwise ignored --
+	// the soft-delete itself has already committed.
+	if err := h.cache.Del(ctx, cacheKey(code)); err != nil {
+		h.logger.Warn("links: cache del failed after delete", "error", err, "code", code)
+	}
+	return c.NoContent(http.StatusNoContent)
 }
 
 // Redirect implements GET /r/:code. Tries the cache first, falls back
@@ -458,6 +502,9 @@ func (h *Links) Redirect(c *echo.Context) error {
 	if err != nil {
 		h.logger.Error("links: redirect lookup failed", "error", err, "code", code)
 		return echo.NewHTTPError(http.StatusInternalServerError, "internal error")
+	}
+	if link.IsDeleted() {
+		return echo.NewHTTPError(http.StatusGone, "link has been deleted")
 	}
 	if link.IsExpired() {
 		return echo.NewHTTPError(http.StatusGone, "link has expired")

--- a/internal/handlers/links_test.go
+++ b/internal/handlers/links_test.go
@@ -123,8 +123,10 @@ func (f *fakeStore) GetLinkByTargetURL(_ context.Context, _ store.DBTX, targetUR
 
 // ListLinks returns the stored links sorted by id descending, mirroring
 // the production ordering. beforeID, when > 0, filters to ids < beforeID.
-// When failList is set, every call returns that error -- used to verify
-// graceful degradation when the database is unavailable.
+// Soft-deleted rows are excluded so the fake matches what the SQL
+// implementation does (`WHERE deleted_at IS NULL`). When failList is
+// set, every call returns that error -- used to verify graceful
+// degradation when the database is unavailable.
 func (f *fakeStore) ListLinks(_ context.Context, _ store.DBTX, limit int, beforeID int64) ([]store.Link, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -133,6 +135,9 @@ func (f *fakeStore) ListLinks(_ context.Context, _ store.DBTX, limit int, before
 	}
 	all := make([]store.Link, 0, len(f.links))
 	for _, l := range f.links {
+		if l.DeletedAt != nil {
+			continue
+		}
 		if beforeID > 0 && l.ID >= beforeID {
 			continue
 		}
@@ -143,6 +148,24 @@ func (f *fakeStore) ListLinks(_ context.Context, _ store.DBTX, limit int, before
 		all = all[:limit]
 	}
 	return all, nil
+}
+
+// SoftDeleteLink mirrors store.Store.SoftDeleteLink: stamps DeletedAt
+// on a live row, returns store.ErrNotFound if the code is absent or
+// already deleted. Failure injection isn't wired here because the
+// existing tests never need it; add a `failDelete error` field if a
+// future test does.
+func (f *fakeStore) SoftDeleteLink(_ context.Context, _ store.DBTX, code string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	l, ok := f.links[code]
+	if !ok || l.DeletedAt != nil {
+		return store.ErrNotFound
+	}
+	now := time.Now()
+	l.DeletedAt = &now
+	f.links[code] = l
+	return nil
 }
 
 // fakeCache implements handlers.LinkCache against an in-memory map. TTL is
@@ -805,5 +828,175 @@ func TestCachePut_ClampsTTLToExpiry(t *testing.T) {
 	cc.mu.Unlock()
 	if ttl <= 0 || ttl > 5*time.Minute+time.Second {
 		t.Errorf("cache TTL = %v, want <=5m (clamped to remaining lifetime)", ttl)
+	}
+}
+
+// --- Delete (soft-delete) ---------------------------------------------------
+
+// TestDelete_LiveCodeReturns204AndStampsDeletedAt: the happy path.
+// First DELETE flips the row to soft-deleted and returns 204 with no
+// body. We assert via the fake's internal state rather than going
+// through the API again because subsequent assertions (Get-after-delete
+// returns 410, Redirect-after-delete returns 410) get their own tests
+// below -- one assertion per test keeps failure messages pointed at
+// the actually-broken layer.
+func TestDelete_LiveCodeReturns204AndStampsDeletedAt(t *testing.T) {
+	t.Parallel()
+	st, cc := newFakeStore(), newFakeCache()
+	if _, err := st.CreateLink(context.Background(), nil, "live123", "https://example.com", nil); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	e, _ := newHandlerWithCache(t, st, cc, &scriptedGen{})
+
+	rec, body := doJSON(t, e, http.MethodDelete, "/api/v1/links/live123", "")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, body = %s", rec.Code, string(body))
+	}
+	if len(body) != 0 {
+		t.Errorf("expected empty body on 204, got %q", string(body))
+	}
+
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	got := st.links["live123"]
+	if got.DeletedAt == nil {
+		t.Fatal("DeletedAt is nil; expected soft-delete to have stamped it")
+	}
+	if got.TargetURL != "https://example.com" {
+		t.Errorf("TargetURL changed: %q", got.TargetURL)
+	}
+}
+
+// TestDelete_InvalidatesCacheEntry: a redirect that previously cached
+// the target must not keep serving it after the row is soft-deleted.
+// We seed the cache directly (rather than walking through Redirect)
+// to keep the assertion narrowly scoped to the cache-invalidation
+// behavior of Delete itself.
+func TestDelete_InvalidatesCacheEntry(t *testing.T) {
+	t.Parallel()
+	st, cc := newFakeStore(), newFakeCache()
+	if _, err := st.CreateLink(context.Background(), nil, "cachehit", "https://example.com", nil); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// Pre-populate the cache to simulate a prior /r/cachehit.
+	if err := cc.Set(context.Background(), "link:cachehit", "https://example.com", time.Hour); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+	e, _ := newHandlerWithCache(t, st, cc, &scriptedGen{})
+
+	rec, _ := doJSON(t, e, http.MethodDelete, "/api/v1/links/cachehit", "")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	if _, present := cc.values["link:cachehit"]; present {
+		t.Error("cache entry survived DELETE; Del should have invalidated it")
+	}
+}
+
+// TestDelete_UnknownCodeReturns404: there is no live row with that
+// code -- could be a typo, a never-existed code, or one that was
+// already deleted. All three collapse to the same not_found shape;
+// the API doesn't distinguish "never existed" from "already deleted"
+// to avoid leaking lifecycle metadata to clients that have no business
+// inspecting it.
+func TestDelete_UnknownCodeReturns404(t *testing.T) {
+	t.Parallel()
+	st, cc := newFakeStore(), newFakeCache()
+	e, _ := newHandlerWithCache(t, st, cc, &scriptedGen{})
+
+	rec, body := doJSON(t, e, http.MethodDelete, "/api/v1/links/nosuch1", "")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", rec.Code, string(body))
+	}
+	if got := decodeError(t, body); got.Code != handlers.ErrCodeNotFound {
+		t.Errorf("error code = %q, want %q", got.Code, handlers.ErrCodeNotFound)
+	}
+}
+
+// TestDelete_SecondDeleteReturns404: documents that DELETE is
+// semantically idempotent (the second call does not re-delete or
+// resurrect the row) but not response-shape idempotent: 204 then 404.
+// Clients that need 204+204 can collapse the two themselves.
+func TestDelete_SecondDeleteReturns404(t *testing.T) {
+	t.Parallel()
+	st, cc := newFakeStore(), newFakeCache()
+	if _, err := st.CreateLink(context.Background(), nil, "twice12", "https://example.com", nil); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	e, _ := newHandlerWithCache(t, st, cc, &scriptedGen{})
+
+	rec, _ := doJSON(t, e, http.MethodDelete, "/api/v1/links/twice12", "")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("first DELETE status = %d, want 204", rec.Code)
+	}
+	rec, body := doJSON(t, e, http.MethodDelete, "/api/v1/links/twice12", "")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("second DELETE status = %d, body = %s", rec.Code, string(body))
+	}
+}
+
+// TestDelete_InvalidCodeShapeReturns404: codes that fail
+// shortener.ValidCode (length, alphabet, ...) are rejected at the
+// edge with the same not_found response a missing code would
+// produce. Returning 422 here would leak that the API does
+// shape-validation on the path parameter, which doesn't help any
+// legitimate client.
+func TestDelete_InvalidCodeShapeReturns404(t *testing.T) {
+	t.Parallel()
+	st, cc := newFakeStore(), newFakeCache()
+	e, _ := newHandlerWithCache(t, st, cc, &scriptedGen{})
+
+	rec, body := doJSON(t, e, http.MethodDelete, "/api/v1/links/has-hyphen", "")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", rec.Code, string(body))
+	}
+}
+
+// TestGet_DeletedLinkReturns410: parallels TestGet_ExpiredLinkReturns410.
+// A soft-deleted link must surface a 410 with the link_deleted error
+// code so programmatic clients can distinguish it from both
+// "never existed" (404) and "expired" (410 + link_expired).
+func TestGet_DeletedLinkReturns410(t *testing.T) {
+	t.Parallel()
+	st, cc := newFakeStore(), newFakeCache()
+	if _, err := st.CreateLink(context.Background(), nil, "deleted", "https://example.com", nil); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := st.SoftDeleteLink(context.Background(), nil, "deleted"); err != nil {
+		t.Fatalf("seed delete: %v", err)
+	}
+	e, _ := newHandlerWithCache(t, st, cc, &scriptedGen{})
+
+	rec, body := doJSON(t, e, http.MethodGet, "/api/v1/links/deleted", "")
+	if rec.Code != http.StatusGone {
+		t.Errorf("status = %d, want 410", rec.Code)
+	}
+	if got := decodeError(t, body); got.Code != handlers.ErrCodeLinkDeleted {
+		t.Errorf("error code = %q, want %q", got.Code, handlers.ErrCodeLinkDeleted)
+	}
+}
+
+// TestRedirect_DeletedLinkReturns410: the public redirect surfaces
+// the same 410 a /api/v1/links lookup does. Mirrors the
+// TestRedirect_ExpiredLinkReturns410 shape.
+func TestRedirect_DeletedLinkReturns410(t *testing.T) {
+	t.Parallel()
+	st, cc := newFakeStore(), newFakeCache()
+	if _, err := st.CreateLink(context.Background(), nil, "deleted", "https://gone.example", nil); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := st.SoftDeleteLink(context.Background(), nil, "deleted"); err != nil {
+		t.Fatalf("seed delete: %v", err)
+	}
+	e, _ := newHandlerWithCache(t, st, cc, &scriptedGen{})
+
+	req := httptest.NewRequest(http.MethodGet, "/r/deleted", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusGone {
+		t.Errorf("status = %d, want 410", rec.Code)
 	}
 }

--- a/internal/server/links_integration_test.go
+++ b/internal/server/links_integration_test.go
@@ -202,6 +202,116 @@ func TestLinksAPI_CreateGetRedirectFlow(t *testing.T) {
 	}
 }
 
+// TestLinksAPI_DeleteFlow walks the soft-delete lifecycle through the
+// real HTTP server, real Postgres, real Redis -- the same wires the
+// production stack uses. The flow is:
+//
+//  1. POST creates a link, populating the cache via the create path.
+//  2. /r/:code redirects (302) and lands a cached entry.
+//  3. DELETE returns 204; the cache is invalidated server-side.
+//  4. /r/:code now returns 410 (cache miss + tombstoned row).
+//  5. /api/v1/links/:code returns 410 with `code=link_deleted`,
+//     letting programmatic clients distinguish a retired link from
+//     an unknown one.
+//  6. A second DELETE returns 404 -- documents the API's
+//     semantically-idempotent-but-response-distinct behavior.
+//
+// No unit-test seam exercises the cache-invalidation path against a
+// real Redis, so this test is the safety net for that interaction.
+func TestLinksAPI_DeleteFlow(t *testing.T) {
+	base, stop := startFullServer(t)
+	defer stop()
+
+	// 1. Create.
+	target := "https://example.com/integration/delete/" + randomSuffix(t)
+	body, _ := json.Marshal(map[string]string{"target_url": target})
+	req, _ := http.NewRequestWithContext(t.Context(),
+		http.MethodPost, base+"/api/v1/links", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("POST status = %d", resp.StatusCode)
+	}
+	var created struct {
+		Code string `json:"code"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// 2. Warm the cache via /r so step 4 must observe an explicit
+	// invalidation rather than a serendipitous miss.
+	rreq, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, base+"/r/"+created.Code, nil)
+	rresp, err := httpClientNoRedirect.Do(rreq)
+	if err != nil {
+		t.Fatalf("warmup redirect: %v", err)
+	}
+	_ = rresp.Body.Close()
+	if rresp.StatusCode != http.StatusFound {
+		t.Fatalf("warmup redirect status = %d", rresp.StatusCode)
+	}
+
+	// 3. DELETE.
+	dreq, _ := http.NewRequestWithContext(t.Context(),
+		http.MethodDelete, base+"/api/v1/links/"+created.Code, nil)
+	dresp, err := http.DefaultClient.Do(dreq)
+	if err != nil {
+		t.Fatalf("DELETE: %v", err)
+	}
+	_ = dresp.Body.Close()
+	if dresp.StatusCode != http.StatusNoContent {
+		t.Fatalf("DELETE status = %d, want 204", dresp.StatusCode)
+	}
+
+	// 4. /r/:code -> 410 (cache invalidation + tombstoned row).
+	rreq, _ = http.NewRequestWithContext(t.Context(), http.MethodGet, base+"/r/"+created.Code, nil)
+	rresp, err = httpClientNoRedirect.Do(rreq)
+	if err != nil {
+		t.Fatalf("post-delete redirect: %v", err)
+	}
+	_ = rresp.Body.Close()
+	if rresp.StatusCode != http.StatusGone {
+		t.Errorf("redirect status = %d, want 410", rresp.StatusCode)
+	}
+
+	// 5. /api/v1/links/:code -> 410 + link_deleted.
+	gresp, err := http.Get(base + "/api/v1/links/" + created.Code)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = gresp.Body.Close() }()
+	if gresp.StatusCode != http.StatusGone {
+		t.Errorf("GET status = %d, want 410", gresp.StatusCode)
+	}
+	var errBody struct {
+		Code  string `json:"code"`
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(gresp.Body).Decode(&errBody); err != nil {
+		t.Fatalf("decode err body: %v", err)
+	}
+	if errBody.Code != "link_deleted" {
+		t.Errorf("error code = %q, want link_deleted", errBody.Code)
+	}
+
+	// 6. Second DELETE -> 404 (semantically idempotent, response
+	//    distinct: see Delete handler doc-comment).
+	dreq, _ = http.NewRequestWithContext(t.Context(),
+		http.MethodDelete, base+"/api/v1/links/"+created.Code, nil)
+	dresp, err = http.DefaultClient.Do(dreq)
+	if err != nil {
+		t.Fatalf("second DELETE: %v", err)
+	}
+	_ = dresp.Body.Close()
+	if dresp.StatusCode != http.StatusNotFound {
+		t.Errorf("second DELETE status = %d, want 404", dresp.StatusCode)
+	}
+}
+
 func TestLinksAPI_UnknownCodeReturns404(t *testing.T) {
 	base, stop := startFullServer(t)
 	defer stop()

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -85,9 +85,10 @@ type DBTX interface {
 
 // Link is a row from the `links` table.
 //
-// ExpiresAt is nil when the link never expires; callers must use a
-// pointer rather than the zero time so "never" and "epoch" stay
-// distinguishable through encoding/json.
+// ExpiresAt and DeletedAt are nil for the common case (never expires,
+// not deleted). Callers must use pointers rather than the zero time
+// so "never set" stays distinguishable from "set to epoch" through
+// encoding/json and through Postgres NULL handling.
 type Link struct {
 	ID         int64
 	Code       string
@@ -95,12 +96,22 @@ type Link struct {
 	CreatedAt  time.Time
 	ClickCount int64
 	ExpiresAt  *time.Time
+	DeletedAt  *time.Time
 }
 
 // IsExpired reports whether the link has an expiry set and that expiry
 // is in the past. A nil ExpiresAt always returns false ("never expires").
 func (l Link) IsExpired() bool {
 	return l.ExpiresAt != nil && time.Now().After(*l.ExpiresAt)
+}
+
+// IsDeleted reports whether the link has been soft-deleted. A nil
+// DeletedAt always returns false ("not deleted"). The handler layer
+// uses this to surface 410 Gone for retired links the same way it
+// does for expired ones, while the dedup / list paths filter deleted
+// rows out at the SQL level.
+func (l Link) IsDeleted() bool {
+	return l.DeletedAt != nil
 }
 
 // Store is the entry point for all DB access. It owns a pgx pool which it
@@ -212,11 +223,11 @@ func (s *Store) CreateLink(ctx context.Context, db DBTX, code, targetURL string,
 	const q = `
 		INSERT INTO links (code, target_url, expires_at)
 		VALUES ($1, $2, $3)
-		RETURNING id, code, target_url, created_at, click_count, expires_at
+		RETURNING id, code, target_url, created_at, click_count, expires_at, deleted_at
 	`
 	var l Link
 	err := db.QueryRow(ctx, q, code, targetURL, expiresAt).
-		Scan(&l.ID, &l.Code, &l.TargetURL, &l.CreatedAt, &l.ClickCount, &l.ExpiresAt)
+		Scan(&l.ID, &l.Code, &l.TargetURL, &l.CreatedAt, &l.ClickCount, &l.ExpiresAt, &l.DeletedAt)
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == uniqueViolation {
@@ -267,19 +278,25 @@ func (s *Store) ListLinks(ctx context.Context, db DBTX, limit int, beforeID int6
 		rows pgx.Rows
 		err  error
 	)
+	// Soft-deleted rows are filtered out of the recent list: a
+	// retired link has no business reappearing in the public feed,
+	// and the deleted_at IS NOT NULL partial index keeps the filter
+	// cheap regardless of the deleted-row volume.
 	if beforeID > 0 {
 		const q = `
-			SELECT id, code, target_url, created_at, click_count, expires_at
+			SELECT id, code, target_url, created_at, click_count, expires_at, deleted_at
 			FROM links
 			WHERE id < $1
+			  AND deleted_at IS NULL
 			ORDER BY id DESC
 			LIMIT $2
 		`
 		rows, err = db.Query(ctx, q, beforeID, limit)
 	} else {
 		const q = `
-			SELECT id, code, target_url, created_at, click_count, expires_at
+			SELECT id, code, target_url, created_at, click_count, expires_at, deleted_at
 			FROM links
+			WHERE deleted_at IS NULL
 			ORDER BY id DESC
 			LIMIT $1
 		`
@@ -293,7 +310,7 @@ func (s *Store) ListLinks(ctx context.Context, db DBTX, limit int, beforeID int6
 	out := make([]Link, 0, limit)
 	for rows.Next() {
 		var l Link
-		if err := rows.Scan(&l.ID, &l.Code, &l.TargetURL, &l.CreatedAt, &l.ClickCount, &l.ExpiresAt); err != nil {
+		if err := rows.Scan(&l.ID, &l.Code, &l.TargetURL, &l.CreatedAt, &l.ClickCount, &l.ExpiresAt, &l.DeletedAt); err != nil {
 			return nil, fmt.Errorf("store: list links: scan: %w", err)
 		}
 		out = append(out, l)
@@ -305,20 +322,21 @@ func (s *Store) ListLinks(ctx context.Context, db DBTX, limit int, beforeID int6
 }
 
 // GetLinkByCode looks up a link by its short code. Returns ErrNotFound when
-// the row is missing. Expired rows are still returned so callers can
-// distinguish 410 from 404 themselves; check Link.IsExpired.
+// the row is missing. Expired and soft-deleted rows are still returned
+// so callers can distinguish 410 from 404 themselves; check
+// Link.IsExpired and Link.IsDeleted.
 func (s *Store) GetLinkByCode(ctx context.Context, db DBTX, code string) (Link, error) {
 	if db == nil {
 		db = s.pool
 	}
 	const q = `
-		SELECT id, code, target_url, created_at, click_count, expires_at
+		SELECT id, code, target_url, created_at, click_count, expires_at, deleted_at
 		FROM links
 		WHERE code = $1
 	`
 	var l Link
 	err := db.QueryRow(ctx, q, code).
-		Scan(&l.ID, &l.Code, &l.TargetURL, &l.CreatedAt, &l.ClickCount, &l.ExpiresAt)
+		Scan(&l.ID, &l.Code, &l.TargetURL, &l.CreatedAt, &l.ClickCount, &l.ExpiresAt, &l.DeletedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return Link{}, ErrNotFound
@@ -328,18 +346,21 @@ func (s *Store) GetLinkByCode(ctx context.Context, db DBTX, code string) (Link, 
 	return l, nil
 }
 
-// GetLinkByTargetURL returns the oldest non-expired permanent link with
-// the exact target_url. Used by the API to dedupe auto-generated codes
-// -- if the caller is shortening a URL that's already in the table,
-// return its existing code instead of minting a new one.
+// GetLinkByTargetURL returns the oldest non-expired, non-deleted
+// permanent link with the exact target_url. Used by the API to dedupe
+// auto-generated codes -- if the caller is shortening a URL that's
+// already in the table, return its existing code instead of minting a
+// new one.
 //
 // Rows that have an expiry set (whether or not yet past) are excluded
 // so dedup never reuses an ephemeral link as if it were permanent;
 // callers asking for an expiring code already opt out of dedup at the
-// handler layer. Multiple permanent rows can legally share a target
-// (a user-supplied code is allowed even when an auto-generated row
-// already covers the same target), so we deliberately pick the oldest
-// by id ASC for stable behavior.
+// handler layer. Soft-deleted rows are likewise excluded -- a retired
+// link must never be silently re-served as a dedup hit. Multiple
+// permanent rows can legally share a target (a user-supplied code is
+// allowed even when an auto-generated row already covers the same
+// target), so we deliberately pick the oldest by id ASC for stable
+// behavior.
 //
 // Returns ErrNotFound when no row matches.
 func (s *Store) GetLinkByTargetURL(ctx context.Context, db DBTX, targetURL string) (Link, error) {
@@ -347,16 +368,17 @@ func (s *Store) GetLinkByTargetURL(ctx context.Context, db DBTX, targetURL strin
 		db = s.pool
 	}
 	const q = `
-		SELECT id, code, target_url, created_at, click_count, expires_at
+		SELECT id, code, target_url, created_at, click_count, expires_at, deleted_at
 		FROM links
 		WHERE target_url = $1
 		  AND expires_at IS NULL
+		  AND deleted_at IS NULL
 		ORDER BY id ASC
 		LIMIT 1
 	`
 	var l Link
 	err := db.QueryRow(ctx, q, targetURL).
-		Scan(&l.ID, &l.Code, &l.TargetURL, &l.CreatedAt, &l.ClickCount, &l.ExpiresAt)
+		Scan(&l.ID, &l.Code, &l.TargetURL, &l.CreatedAt, &l.ClickCount, &l.ExpiresAt, &l.DeletedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return Link{}, ErrNotFound
@@ -364,4 +386,36 @@ func (s *Store) GetLinkByTargetURL(ctx context.Context, db DBTX, targetURL strin
 		return Link{}, fmt.Errorf("store: get link by target url: %w", err)
 	}
 	return l, nil
+}
+
+// SoftDeleteLink marks the link with the given code as deleted by
+// stamping deleted_at = now(). It is idempotent in semantic only:
+// the first call returns nil, subsequent calls (or a call against a
+// non-existent code) return ErrNotFound, since the WHERE clause is
+// scoped to live rows so the affected-row count tells the caller
+// whether anything actually changed. Higher layers translate
+// ErrNotFound to 404 the same way they do for GetLinkByCode.
+//
+// The row is left in the table -- expires_at, click_count, and
+// every audit column survive the delete -- so a future undelete
+// recipe could clear deleted_at and bring the link back if the
+// product ever needs it.
+func (s *Store) SoftDeleteLink(ctx context.Context, db DBTX, code string) error {
+	if db == nil {
+		db = s.pool
+	}
+	const q = `
+		UPDATE links
+		SET deleted_at = now()
+		WHERE code = $1
+		  AND deleted_at IS NULL
+	`
+	tag, err := db.Exec(ctx, q, code)
+	if err != nil {
+		return fmt.Errorf("store: soft delete link: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
 }

--- a/internal/store/postgres_integration_test.go
+++ b/internal/store/postgres_integration_test.go
@@ -276,3 +276,78 @@ func TestTransaction_RollbackDiscardsInsert(t *testing.T) {
 		t.Errorf("after rollback, err = %v, want ErrNotFound", err)
 	}
 }
+
+// TestSoftDeleteLink_StampsTombstoneAndExcludesFromListAndDedup
+// exercises the full SQL-level soft-delete contract:
+//
+//  1. The first SoftDeleteLink call returns nil and stamps deleted_at.
+//  2. GetLinkByCode still returns the row (so handlers can surface 410)
+//     but Link.IsDeleted() is true.
+//  3. ListLinks no longer includes the row (WHERE deleted_at IS NULL).
+//  4. GetLinkByTargetURL no longer matches the row, so dedup mints a
+//     fresh code rather than resurrecting a retired one.
+//  5. A second SoftDeleteLink call against the same code returns
+//     ErrNotFound, matching the handler-layer behavior of "204 then 404".
+func TestSoftDeleteLink_StampsTombstoneAndExcludesFromListAndDedup(t *testing.T) {
+	s := newStore(t)
+	ctx := t.Context()
+	code := uniqueCode(t)
+	target := "https://example.com/softdel/" + code
+
+	if _, err := s.CreateLink(ctx, nil, code, target, nil); err != nil {
+		t.Fatalf("CreateLink: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = s.Pool().Exec(context.Background(), `DELETE FROM links WHERE code = $1`, code)
+	})
+
+	if err := s.SoftDeleteLink(ctx, nil, code); err != nil {
+		t.Fatalf("first SoftDeleteLink: %v", err)
+	}
+
+	// 1+2: the row survives but is now tombstoned.
+	got, err := s.GetLinkByCode(ctx, nil, code)
+	if err != nil {
+		t.Fatalf("GetLinkByCode after soft-delete: %v", err)
+	}
+	if !got.IsDeleted() {
+		t.Errorf("IsDeleted = false, want true (DeletedAt = %v)", got.DeletedAt)
+	}
+
+	// 3: ListLinks filters deleted rows out. Use a wide limit + the
+	// just-inserted ID as an upper bound so the assertion is robust
+	// against unrelated concurrent test rows.
+	rows, err := s.ListLinks(ctx, nil, 100, got.ID+1)
+	if err != nil {
+		t.Fatalf("ListLinks: %v", err)
+	}
+	for _, l := range rows {
+		if l.Code == code {
+			t.Errorf("ListLinks returned the soft-deleted row (code=%q)", code)
+		}
+	}
+
+	// 4: dedup must not resurrect the deleted row.
+	if _, err := s.GetLinkByTargetURL(ctx, nil, target); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("GetLinkByTargetURL after soft-delete: err = %v, want ErrNotFound", err)
+	}
+
+	// 5: idempotency boundary -- second delete is a no-op that
+	// surfaces ErrNotFound, mirroring the API's 204-then-404 shape.
+	if err := s.SoftDeleteLink(ctx, nil, code); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("second SoftDeleteLink: err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestSoftDeleteLink_UnknownCodeReturnsErrNotFound covers the
+// "never-existed" case as a separate path from the "already deleted"
+// case in the test above; together they cover both branches of the
+// "WHERE code = $1 AND deleted_at IS NULL" UPDATE returning 0 rows.
+func TestSoftDeleteLink_UnknownCodeReturnsErrNotFound(t *testing.T) {
+	s := newStore(t)
+	ctx := t.Context()
+
+	if err := s.SoftDeleteLink(ctx, nil, uniqueCode(t)); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}

--- a/migrations/00004_add_deleted_at.sql
+++ b/migrations/00004_add_deleted_at.sql
@@ -1,0 +1,36 @@
+-- +goose Up
+-- +goose StatementBegin
+-- deleted_at: optional soft-delete tombstone. NULL means "not deleted";
+-- a non-NULL timestamp means the link is retired. The redirect handler
+-- returns 410 Gone past this column the same way it does for expires_at,
+-- so a soft-deleted link looks identical to an expired one to the
+-- public.
+--
+-- Soft delete is preferred over a hard DELETE so audit trails (who
+-- created what, click history) survive a takedown. The column is
+-- intentionally separate from expires_at: an expiring link can also be
+-- deleted, and the two predicates compose without either column having
+-- to encode the other's meaning.
+--
+-- The original UNIQUE constraint on `code` is left in place: even after
+-- soft delete, the code stays reserved. That keeps the schema simple
+-- (no partial unique index gymnastics) and avoids the security
+-- footgun where a previously-shortened URL's code could be re-issued
+-- to a different target. If code reuse is ever wanted, a follow-up
+-- migration can drop the constraint and replace it with
+-- `UNIQUE (code) WHERE deleted_at IS NULL`.
+ALTER TABLE links ADD COLUMN deleted_at TIMESTAMPTZ;
+
+-- Partial index restricted to the small subset of deleted rows. Keeps
+-- the dedup / list / lookup hot paths -- which all filter
+-- `deleted_at IS NULL` -- cheap by leaving the bulk of the table
+-- unindexed for this column. Useful for any future janitor that
+-- prunes deleted rows on a schedule.
+CREATE INDEX links_deleted_at_idx ON links (deleted_at) WHERE deleted_at IS NOT NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS links_deleted_at_idx;
+ALTER TABLE links DROP COLUMN IF EXISTS deleted_at;
+-- +goose StatementEnd


### PR DESCRIPTION
Adds the soft-delete lifecycle the rewrite plan called for: a `DELETE` endpoint that retires a link without losing its audit history, plus the surrounding plumbing (`deleted_at` column, store filter updates, `410 link_deleted` for the public surface, cache invalidation, full test coverage).

Schema (`migrations/00004_add_deleted_at.sql`)
==============================================

New `deleted_at TIMESTAMPTZ` column on `links`. NULL means "live"; non-NULL is a tombstone. The original `code UNIQUE` constraint is intentionally left in place: a soft-deleted code stays reserved forever, which keeps the schema simple and avoids the security footgun of re-issuing a previously-published code to a different target. If code reuse ever becomes a product requirement, a follow-up migration can drop the constraint and replace it with `UNIQUE (code) WHERE deleted_at IS NULL`.

A partial index `links_deleted_at_idx ON links (deleted_at) WHERE deleted_at IS NOT NULL` covers any future janitor pass without fattening the hot read path -- live-row queries all filter `deleted_at IS NULL` and the bulk of the table stays out of the new index.

Store layer (`internal/store/postgres.go`)
==========================================

- `Link.DeletedAt *time.Time` + `Link.IsDeleted()` helper, mirroring the existing `ExpiresAt` / `IsExpired()` pair.
- New `SoftDeleteLink(ctx, db, code) error` that runs `UPDATE links SET deleted_at = now() WHERE code = $1 AND deleted_at IS NULL` and returns `ErrNotFound` when the affected row count is zero. The "AND deleted_at IS NULL" predicate is what makes a second DELETE surface as 404 -- semantically idempotent, response distinct.
- `GetLinkByCode` keeps returning soft-deleted rows so handlers can surface `410` (parallels the existing expired-row handling). The filter is in the *handler* layer for the public read paths and in the *SQL* layer for the everywhere-else paths.
- `GetLinkByTargetURL` (dedup) and `ListLinks` (recent feed) both gain `AND deleted_at IS NULL` -- a retired link must not be resurrected as a dedup hit, and must not reappear in the public list. The new partial index keeps the cost of this filter negligible.
- All `SELECT` and `INSERT ... RETURNING` clauses include the new column so `Link` round-trips without ad-hoc reconstruction.

Handler layer (`internal/handlers/links.go`)
============================================

- `Links.Delete` mounted at `DELETE /api/v1/links/:code`. Returns `204 No Content` on success, `404 not_found` for unknown / already-deleted / shape-invalid codes, `500 internal_error` for storage failures. Best-effort `cache.Del("link:"+code)` after the soft-delete commits so a subsequent `/r/:code` immediately surfaces 410 rather than waiting out the cache TTL.
- New `ErrCodeLinkDeleted = "link_deleted"` constant. `Get` and `Redirect` now check `IsDeleted()` *before* `IsExpired()` so a link that was both expired and deleted reports the human-meaningful "deleted" reason rather than the bystander "expired".
- `LinkStore` interface gains `SoftDeleteLink`; the in-memory `fakeStore` test fixture implements it and the test fake's `ListLinks` now skips deleted rows so unit tests match the SQL semantics.

Tests
=====

Unit (`internal/handlers/links_test.go`):
- `TestDelete_LiveCodeReturns204AndStampsDeletedAt` -- happy path, asserts both the HTTP shape and the underlying `DeletedAt` flip.
- `TestDelete_InvalidatesCacheEntry` -- pre-seeds the cache, asserts it's gone after the DELETE (no test seam exists for the cache+store interaction in unit-land otherwise).
- `TestDelete_UnknownCodeReturns404` + `TestDelete_SecondDeleteReturns404`
  + `TestDelete_InvalidCodeShapeReturns404` -- the three branches that all collapse to `404 not_found`.
- `TestGet_DeletedLinkReturns410` + `TestRedirect_DeletedLinkReturns410` -- mirror the existing expired-link tests so the parallel between `link_expired` and `link_deleted` is locked in.

Integration (Postgres, `internal/store/postgres_integration_test.go`):
- `TestSoftDeleteLink_StampsTombstoneAndExcludesFromListAndDedup` -- walks the full SQL contract: stamp + Get-still-returns + List excludes + dedup excludes + double-delete-is-ErrNotFound.
- `TestSoftDeleteLink_UnknownCodeReturnsErrNotFound` -- isolates the never-existed branch from the already-deleted branch.

Integration (full server + Redis, `internal/server/links_integration_test.go`):
- `TestLinksAPI_DeleteFlow` -- end-to-end through real HTTP +
  Postgres + Redis: POST -> warm cache via /r -> DELETE 204 ->
  /r returns 410 (cache invalidation works against a real Redis, not just the in-memory fake) -> Get returns 410 + link_deleted -> second DELETE returns 404. This is the safety net for the cache-Del path that no unit test can exercise.

Docs
====

`README.md` API table gets the new endpoint row + a paragraph explaining the soft-delete semantic (tombstone, audit retention, 204-then-404 idempotency, cache + list + dedup invalidation). Error-code table gets the new `link_deleted` row.