### PR TITLE
chore(commitlint): drop `header-max-length` rule

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -25,6 +25,6 @@ export default {
       "never",
       ["start-case", "pascal-case", "upper-case"],
     ],
-    "header-max-length": [2, "always", 100],
+    "header-max-length": [0],
   },
 };


### PR DESCRIPTION
Long Dependabot commit headers (e.g. grouped npm bumps) routinely exceed the 100-char limit

and fail `commitlint`. Disable the rule so we stop blocking otherwise-valid commits.