### PR TITLE
fix(commitlint): drop dead commitlint block from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,5 @@
     "@commitlint/config-conventional": "^21.0.0",
     "@stoplight/spectral-cli": "^6.15.1",
     "husky": "^9.1.7"
-  },
-  "commitlint": {
-    "extends": [
-      "@commitlint/config-conventional"
-    ]
   }
 }


### PR DESCRIPTION
## Summary

The repo has **two commitlint configs** and the wrong one wins.

- `package.json` carries a top-level `"commitlint"` block (just
  `extends: ["@commitlint/config-conventional"]`).
- `commitlint.config.mjs` carries the project's actual rule
  overrides (`type-enum`, `subject-case`, and most importantly
  `"header-max-length": [0]`).

cosmiconfig's discovery order prefers `package.json#commitlint` over
standalone `commitlint.config.{cjs,js,mjs}` files, so the
package.json block silently shadows the `.mjs` file. The
`header-max-length` opt-out added in `3552b47` therefore never took
effect, and `just commitlint-msg` / the PR-title CI check have been
enforcing the default 100-char header limit ever since.

## Reproducer

A typical grouped Dependabot title at 104 characters:

```
chore(deps): bump step-security/harden-runner from 2.19.0 to 2.19.1 in the actions-minor-and-patch group
```

Run against the current config:

```text
✖ header must not be longer than 100 characters, current length is 104 [header-max-length]
```

Force the right config and it passes:

```sh
echo '<title>' | npx --no -- commitlint --config commitlint.config.mjs   # ok
```

## Fix

Drop the redundant `commitlint` block from `package.json`.
cosmiconfig falls through to `commitlint.config.mjs`, restoring the
project's type-enum + subject-case rules **and** the
`header-max-length: [0]` opt-out.

## Verification

Locally:

```sh
just commitlint-msg \
  "chore(deps): bump step-security/harden-runner from 2.19.0 to 2.19.1 in the actions-minor-and-patch group"
# ok (was: 104 > 100 header-max-length)

just commitlint-msg "feat: add things"
# ok

just commitlint-msg "wip: nope"
# ✖ type-enum (still enforced)
```
