### PR TITLE
feat: block startup when DB schema lags embedded migrations

### DIFF
--- a/.github/actions/setup-toolchain/action.yaml
+++ b/.github/actions/setup-toolchain/action.yaml
@@ -41,3 +41,9 @@ runs:
         cache-dependency-path: ${{ inputs.node-cache-dependency-path }}
 
     - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+      with:
+        # setup-just resolves public releases from casey/just.
+        # Avoid forwarding the workflow token here: for PR contexts,
+        # the injected token can be scoped or invalid for that cross-repo
+        # lookup and has intermittently produced 401 Bad credentials.
+        github-token: ""

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os/signal"
 	"syscall"
 
@@ -38,6 +39,18 @@ func newRunCmd() *cobra.Command {
 				logger.Info("auto_migrate=true; applying migrations before serving")
 				if err := migrate.Up(cmd.Context(), cfg.DatabaseURL); err != nil {
 					return err
+				}
+			} else {
+				current, latest, err := migrate.Versions(cmd.Context(), cfg.DatabaseURL)
+				if err != nil {
+					return err
+				}
+				if current < latest {
+					return fmt.Errorf(
+						"database schema is behind embedded migrations (current=%d latest=%d); run `url-shortener migrate up` or set URL_SHORTENER_AUTO_MIGRATE=true",
+						current,
+						latest,
+					)
 				}
 			}
 			st, err := store.NewWithPool(cmd.Context(), cfg.DatabaseURL, store.PoolConfig{

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -15,6 +15,33 @@ import (
 	"github.com/vancanhuit/url-shortener/internal/store"
 )
 
+var (
+	migrateUpFn       = migrate.Up
+	migrateVersionsFn = migrate.Versions
+)
+
+func ensureSchemaCurrent(cmd *cobra.Command, cfg config.Config) error {
+	if cfg.AutoMigrate {
+		if err := migrateUpFn(cmd.Context(), cfg.DatabaseURL); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	current, latest, err := migrateVersionsFn(cmd.Context(), cfg.DatabaseURL)
+	if err != nil {
+		return err
+	}
+	if current < latest {
+		return fmt.Errorf(
+			"database schema is behind embedded migrations (current=%d latest=%d); run `url-shortener migrate up` or set URL_SHORTENER_AUTO_MIGRATE=true",
+			current,
+			latest,
+		)
+	}
+	return nil
+}
+
 func newRunCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "run",
@@ -37,21 +64,9 @@ func newRunCmd() *cobra.Command {
 			// config.Validate); DatabaseURL is guaranteed non-empty here.
 			if cfg.AutoMigrate {
 				logger.Info("auto_migrate=true; applying migrations before serving")
-				if err := migrate.Up(cmd.Context(), cfg.DatabaseURL); err != nil {
-					return err
-				}
-			} else {
-				current, latest, err := migrate.Versions(cmd.Context(), cfg.DatabaseURL)
-				if err != nil {
-					return err
-				}
-				if current < latest {
-					return fmt.Errorf(
-						"database schema is behind embedded migrations (current=%d latest=%d); run `url-shortener migrate up` or set URL_SHORTENER_AUTO_MIGRATE=true",
-						current,
-						latest,
-					)
-				}
+			}
+			if err := ensureSchemaCurrent(cmd, cfg); err != nil {
+				return err
 			}
 			st, err := store.NewWithPool(cmd.Context(), cfg.DatabaseURL, store.PoolConfig{
 				MaxConns:          cfg.DBMaxConns,

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/vancanhuit/url-shortener/internal/config"
+)
+
+func TestEnsureSchemaCurrent_AutoMigrateRunsUp(t *testing.T) {
+	t.Parallel()
+
+	origUp := migrateUpFn
+	origVersions := migrateVersionsFn
+	t.Cleanup(func() {
+		migrateUpFn = origUp
+		migrateVersionsFn = origVersions
+	})
+
+	upCalled := false
+	versionsCalled := false
+	migrateUpFn = func(_ context.Context, _ string) error {
+		upCalled = true
+		return nil
+	}
+	migrateVersionsFn = func(_ context.Context, _ string) (int64, int64, error) {
+		versionsCalled = true
+		return 0, 0, nil
+	}
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	cfg := config.Config{AutoMigrate: true, DatabaseURL: "postgres://example"}
+
+	if err := ensureSchemaCurrent(cmd, cfg); err != nil {
+		t.Fatalf("ensureSchemaCurrent() error = %v", err)
+	}
+	if !upCalled {
+		t.Fatal("migrate.Up was not called")
+	}
+	if versionsCalled {
+		t.Fatal("migrate.Versions should not be called when auto_migrate=true")
+	}
+}
+
+func TestEnsureSchemaCurrent_BehindSchemaReturnsActionableError(t *testing.T) {
+	t.Parallel()
+
+	origUp := migrateUpFn
+	origVersions := migrateVersionsFn
+	t.Cleanup(func() {
+		migrateUpFn = origUp
+		migrateVersionsFn = origVersions
+	})
+
+	migrateUpFn = func(_ context.Context, _ string) error {
+		t.Fatal("migrate.Up should not be called when auto_migrate=false")
+		return nil
+	}
+	migrateVersionsFn = func(_ context.Context, _ string) (int64, int64, error) {
+		return 3, 4, nil
+	}
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	cfg := config.Config{AutoMigrate: false, DatabaseURL: "postgres://example"}
+
+	err := ensureSchemaCurrent(cmd, cfg)
+	if err == nil {
+		t.Fatal("ensureSchemaCurrent() error = nil, want non-nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "database schema is behind embedded migrations") {
+		t.Fatalf("error = %q, want behind-schema message", msg)
+	}
+	if !strings.Contains(msg, "current=3 latest=4") {
+		t.Fatalf("error = %q, want current/latest values", msg)
+	}
+}
+
+func TestEnsureSchemaCurrent_PropagatesVersionsError(t *testing.T) {
+	t.Parallel()
+
+	origUp := migrateUpFn
+	origVersions := migrateVersionsFn
+	t.Cleanup(func() {
+		migrateUpFn = origUp
+		migrateVersionsFn = origVersions
+	})
+
+	want := errors.New("boom")
+	migrateVersionsFn = func(_ context.Context, _ string) (int64, int64, error) {
+		return 0, 0, want
+	}
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	cfg := config.Config{AutoMigrate: false, DatabaseURL: "postgres://example"}
+
+	err := ensureSchemaCurrent(cmd, cfg)
+	if !errors.Is(err, want) {
+		t.Fatalf("ensureSchemaCurrent() error = %v, want %v", err, want)
+	}
+}

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -7,6 +7,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"io/fs"
+	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
@@ -42,6 +44,53 @@ func Status(ctx context.Context, databaseURL string) error {
 	return run(ctx, databaseURL, func(db *sql.DB) error {
 		return goose.StatusContext(ctx, db, migrationsDir)
 	})
+}
+
+// Versions returns the current goose_db_version in the target database and
+// the latest embedded migration version.
+func Versions(ctx context.Context, databaseURL string) (current int64, latest int64, err error) {
+	latest, err = latestEmbeddedVersion()
+	if err != nil {
+		return 0, 0, err
+	}
+
+	err = run(ctx, databaseURL, func(db *sql.DB) error {
+		v, e := goose.EnsureDBVersionContext(ctx, db)
+		if e != nil {
+			return e
+		}
+		current = v
+		return nil
+	})
+	if err != nil {
+		return 0, 0, err
+	}
+	return current, latest, nil
+}
+
+func latestEmbeddedVersion() (int64, error) {
+	entries, err := fs.ReadDir(migrations.FS, migrationsDir)
+	if err != nil {
+		return 0, fmt.Errorf("migrate: read embedded migrations: %w", err)
+	}
+
+	var latest int64
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".sql") {
+			continue
+		}
+		version, err := goose.NumericComponent(e.Name())
+		if err != nil {
+			return 0, fmt.Errorf("migrate: parse migration version %q: %w", e.Name(), err)
+		}
+		if version > latest {
+			latest = version
+		}
+	}
+	if latest == 0 {
+		return 0, goose.ErrNoMigrationFiles
+	}
+	return latest, nil
 }
 
 // run opens a pgx pool, adapts it to *sql.DB for goose, configures goose with

--- a/internal/migrate/versions_integration_test.go
+++ b/internal/migrate/versions_integration_test.go
@@ -1,0 +1,42 @@
+//go:build integration
+
+package migrate_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/vancanhuit/url-shortener/internal/migrate"
+)
+
+func testDatabaseURL(t *testing.T) string {
+	t.Helper()
+	url := os.Getenv("URL_SHORTENER_TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("URL_SHORTENER_TEST_DATABASE_URL not set; skipping integration test")
+	}
+	return url
+}
+
+// TestVersions_CurrentMatchesLatestAtRuntime exercises the preflight source
+// of truth against a real Postgres: the DB migration version that goose sees
+// should match the latest embedded migration after an `Up`.
+func TestVersions_CurrentMatchesLatestAtRuntime(t *testing.T) {
+	url := testDatabaseURL(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	if err := migrate.Up(ctx, url); err != nil {
+		t.Fatalf("migrate.Up: %v", err)
+	}
+
+	current, latest, err := migrate.Versions(ctx, url)
+	if err != nil {
+		t.Fatalf("migrate.Versions: %v", err)
+	}
+	if current != latest {
+		t.Fatalf("migrate.Versions current=%d latest=%d; want equal", current, latest)
+	}
+}

--- a/internal/migrate/versions_test.go
+++ b/internal/migrate/versions_test.go
@@ -1,0 +1,15 @@
+package migrate
+
+import "testing"
+
+func TestLatestEmbeddedVersion(t *testing.T) {
+	t.Parallel()
+
+	got, err := latestEmbeddedVersion()
+	if err != nil {
+		t.Fatalf("latestEmbeddedVersion() error = %v", err)
+	}
+	if got != 4 {
+		t.Fatalf("latestEmbeddedVersion() = %d, want 4", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add `migrate.Versions` to compare DB goose version vs embedded migrations
- add startup preflight in `run` when `URL_SHORTENER_AUTO_MIGRATE=false`
- return a clear actionable error when schema is behind
- add test coverage for embedded latest migration discovery

## Why
This prevents serving traffic against a stale database schema when auto-migrate is intentionally disabled.

## Validation
- `go test ./internal/migrate ./internal/cli ./internal/config`
