### PR TITLE
feat(server): hot-reload TLS certs and cover in tls-smoke

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -434,9 +434,11 @@ compose-smoke:
 #   3. Hit /healthz, /readyz, /version over HTTPS with
 #      `--cacert <tempdir>/rootCA.pem` -- a strict check that the
 #      server is actually serving the cert we just signed.
-#   4. Tear down on exit (success or failure) via trap.
+#   4. Rotate the leaf cert in-place and assert the running server
+#      serves the new cert without restart (hot-reload behavior).
+#   5. Tear down on exit (success or failure) via trap.
 #
-# Requires mkcert + curl + jq on PATH. mkcert install instructions
+# Requires mkcert + curl + jq + openssl on PATH. mkcert install instructions
 # are in the dev-certs recipe doc-comment.
 [group("test")]
 tls-smoke:
@@ -447,6 +449,24 @@ tls-smoke:
         echo 'mkcert not found on PATH; see `just dev-certs` for install instructions.' >&2
         exit 1
     fi
+    if ! command -v openssl >/dev/null 2>&1; then
+        echo 'openssl not found on PATH; required to verify cert hot-reload.' >&2
+        exit 1
+    fi
+
+    tls_serial() {
+        # Extract the currently-served leaf cert serial from the live listener.
+        # -verify_return_error fails fast if the cert chain is not trusted by
+        # the provided CA (guarding against accidental fallback certs).
+        openssl s_client \
+            -connect localhost:8443 \
+            -servername localhost \
+            -CAfile "$cacert" \
+            -verify_return_error \
+            </dev/null 2>/dev/null \
+            | openssl x509 -noout -serial 2>/dev/null \
+            | sed -E 's/^serial=//'
+    }
 
     workdir=$(mktemp -d -t url-shortener-tls-smoke-XXXXXX)
     export TLS_CERTS_DIR="$workdir/certs"
@@ -479,8 +499,8 @@ tls-smoke:
     cacert="$CAROOT/rootCA.pem"
     test -f "$cacert" || { echo "rootCA.pem not at $cacert" >&2; exit 1; }
 
-    echo "== docker compose --profile=tls up --wait =="
-    docker compose --profile=tls up --wait --detach
+    echo "== docker compose --profile=tls up --wait --build =="
+    docker compose --profile=tls up --wait --detach --build
 
     base="https://localhost:8443"
 
@@ -496,6 +516,31 @@ tls-smoke:
     echo "== /version =="
     curl --fail-with-body -sS --cacert "$cacert" "$base/version" \
         | tee /dev/stderr | jq -e 'has("version")' >/dev/null
+
+    echo "== TLS cert hot-reload (rotate leaf cert in place) =="
+    before_serial=$(tls_serial)
+    test -n "$before_serial" || { echo "failed to read initial TLS serial" >&2; exit 1; }
+
+    # Re-issue the leaf cert at the same paths while the server is running.
+    # The server's fsnotify-based TLS reloader should pick this up and start
+    # serving the new cert without restarting the process.
+    mkcert \
+        -cert-file "$TLS_CERTS_DIR/cert.pem" \
+        -key-file  "$TLS_CERTS_DIR/key.pem" \
+        localhost 127.0.0.1 ::1 >/dev/null
+    chmod 0644 "$TLS_CERTS_DIR/key.pem"
+
+    after_serial=""
+    for _ in $(seq 1 50); do
+        after_serial=$(tls_serial || true)
+        if [ -n "$after_serial" ] && [ "$after_serial" != "$before_serial" ]; then
+            break
+        fi
+        sleep 0.1
+    done
+    test -n "$after_serial" || { echo "failed to read TLS serial after rotation" >&2; exit 1; }
+    test "$after_serial" != "$before_serial" \
+        || { echo "TLS cert serial did not change after in-place rotation" >&2; exit 1; }
 
     # Negative check: without --cacert (no host-trust install), the
     # request must fail at TLS verification. Proves the certificate

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 func TestEnsureSchemaCurrent_AutoMigrateRunsUp(t *testing.T) {
-	t.Parallel()
-
 	origUp := migrateUpFn
 	origVersions := migrateVersionsFn
 	t.Cleanup(func() {
@@ -48,8 +46,6 @@ func TestEnsureSchemaCurrent_AutoMigrateRunsUp(t *testing.T) {
 }
 
 func TestEnsureSchemaCurrent_BehindSchemaReturnsActionableError(t *testing.T) {
-	t.Parallel()
-
 	origUp := migrateUpFn
 	origVersions := migrateVersionsFn
 	t.Cleanup(func() {
@@ -83,8 +79,6 @@ func TestEnsureSchemaCurrent_BehindSchemaReturnsActionableError(t *testing.T) {
 }
 
 func TestEnsureSchemaCurrent_PropagatesVersionsError(t *testing.T) {
-	t.Parallel()
-
 	origUp := migrateUpFn
 	origVersions := migrateVersionsFn
 	t.Cleanup(func() {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,7 @@ package server
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -206,11 +207,31 @@ func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
 		)
 		var err error
 		if tlsEnabled {
-			// ServeTLS reads cert+key from disk on every call. The
-			// http.Server.TLSConfig is left at its zero value so Go's
-			// secure defaults apply (TLS 1.2+ minimum from Go 1.18,
-			// modern cipher suites with HTTP/2 support).
-			err = s.http.ServeTLS(ln, s.cfg.TLSCertFile, s.cfg.TLSKeyFile)
+			reloader, reloadErr := newCertReloader(s.cfg.TLSCertFile, s.cfg.TLSKeyFile, s.logger)
+			if reloadErr != nil {
+				errCh <- reloadErr
+				close(errCh)
+				return
+			}
+			stopReload, reloadErr := reloader.start(ctx)
+			if reloadErr != nil {
+				errCh <- reloadErr
+				close(errCh)
+				return
+			}
+			defer stopReload()
+
+			// Serve TLS with a dynamic certificate callback so certificate
+			// replacement on disk takes effect without process restart.
+			tlsCfg := &tls.Config{ //nolint:gosec // secure defaults apply; no legacy overrides set.
+				GetCertificate: reloader.getCertificate,
+			}
+			if s.http.TLSConfig != nil {
+				tlsCfg = s.http.TLSConfig.Clone()
+				tlsCfg.GetCertificate = reloader.getCertificate
+			}
+			s.http.TLSConfig = tlsCfg
+			err = s.http.ServeTLS(ln, "", "")
 		} else {
 			err = s.http.Serve(ln)
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -223,7 +223,7 @@ func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
 
 			// Serve TLS with a dynamic certificate callback so certificate
 			// replacement on disk takes effect without process restart.
-			tlsCfg := &tls.Config{ //nolint:gosec // secure defaults apply; no legacy overrides set.
+			tlsCfg := &tls.Config{
 				GetCertificate: reloader.getCertificate,
 			}
 			if s.http.TLSConfig != nil {

--- a/internal/server/tls_integration_test.go
+++ b/internal/server/tls_integration_test.go
@@ -20,6 +20,8 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"math/big"
@@ -27,6 +29,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -95,6 +98,78 @@ func generateSelfSignedCert(t *testing.T, dir string) (certPath, keyPath string)
 		t.Fatalf("close key.pem: %v", err)
 	}
 	return certPath, keyPath
+}
+
+func overwriteSelfSignedCert(t *testing.T, certPath, keyPath string, serial int64) {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa.GenerateKey: %v", err)
+	}
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(serial),
+		Subject:      pkix.Name{CommonName: fmt.Sprintf("url-shortener-test-%d", serial)},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		DNSNames:     []string{"localhost"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("x509.CreateCertificate: %v", err)
+	}
+
+	tmpCert := certPath + ".tmp"
+	tmpKey := keyPath + ".tmp"
+
+	certFile, err := os.Create(tmpCert)
+	if err != nil {
+		t.Fatalf("create tmp cert: %v", err)
+	}
+	if err := pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: der}); err != nil {
+		t.Fatalf("pem encode cert: %v", err)
+	}
+	if err := certFile.Close(); err != nil {
+		t.Fatalf("close tmp cert: %v", err)
+	}
+
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatalf("MarshalECPrivateKey: %v", err)
+	}
+	keyFile, err := os.OpenFile(tmpKey, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatalf("create tmp key: %v", err)
+	}
+	if err := pem.Encode(keyFile, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}); err != nil {
+		t.Fatalf("pem encode key: %v", err)
+	}
+	if err := keyFile.Close(); err != nil {
+		t.Fatalf("close tmp key: %v", err)
+	}
+
+	if err := os.Rename(tmpCert, certPath); err != nil {
+		t.Fatalf("rename cert: %v", err)
+	}
+	if err := os.Rename(tmpKey, keyPath); err != nil {
+		t.Fatalf("rename key: %v", err)
+	}
+}
+
+func tlsPeerSerial(addr string) (string, error) {
+	conn, err := tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12}) //nolint:gosec // test-only serial probe
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = conn.Close() }()
+	state := conn.ConnectionState()
+	if len(state.PeerCertificates) == 0 {
+		return "", errors.New("peer certificates missing")
+	}
+	return state.PeerCertificates[0].SerialNumber.String(), nil
 }
 
 func TestServer_TLSListenerServesHTTPS(t *testing.T) {
@@ -215,4 +290,101 @@ func TestServer_TLSListenerServesHTTPS(t *testing.T) {
 	case <-time.After(20 * time.Second):
 		t.Error("Serve did not return within 20s of cancellation")
 	}
+}
+
+func TestServer_TLSCertHotReloadWithoutRestart(t *testing.T) {
+	dbURL := os.Getenv("URL_SHORTENER_TEST_DATABASE_URL")
+	redisURL := os.Getenv("URL_SHORTENER_TEST_REDIS_URL")
+	if dbURL == "" || redisURL == "" {
+		t.Skip("URL_SHORTENER_TEST_DATABASE_URL / URL_SHORTENER_TEST_REDIS_URL not set; skipping integration test")
+	}
+
+	certPath, keyPath := generateSelfSignedCert(t, t.TempDir())
+
+	ctx := t.Context()
+	st, err := store.New(ctx, dbURL)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(st.Close)
+	cc, err := cache.New(ctx, redisURL)
+	if err != nil {
+		t.Fatalf("cache.New: %v", err)
+	}
+	t.Cleanup(func() { _ = cc.Close() })
+	gen, err := shortener.NewGenerator(shortener.DefaultLength)
+	if err != nil {
+		t.Fatalf("shortener.NewGenerator: %v", err)
+	}
+
+	cfg := config.Config{
+		Env:         config.EnvDev,
+		Addr:        "127.0.0.1:0",
+		BaseURL:     "https://short.test",
+		LogLevel:    "info",
+		LogFormat:   "text",
+		CodeLength:  shortener.DefaultLength,
+		TLSCertFile: certPath,
+		TLSKeyFile:  keyPath,
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := server.New(cfg, logger, server.Deps{Store: st, Cache: cc, Generator: gen})
+
+	runCtx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve(runCtx, ln) }()
+
+	addr := ln.Addr().String()
+
+	before := ""
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, dialErr := tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12}) //nolint:gosec // test-only probe
+		if dialErr == nil {
+			state := conn.ConnectionState()
+			if len(state.PeerCertificates) > 0 {
+				before = state.PeerCertificates[0].SerialNumber.String()
+				_ = conn.Close()
+				break
+			}
+			_ = conn.Close()
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if before == "" {
+		t.Fatal("TLS listener never became ready")
+	}
+
+	overwriteSelfSignedCert(t, certPath, keyPath, 424242)
+
+	want := strconv.FormatInt(424242, 10)
+	reloadDeadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(reloadDeadline) {
+		got, probeErr := tlsPeerSerial(addr)
+		if probeErr == nil && got == want {
+			cancel()
+			select {
+			case serveErr := <-done:
+				if serveErr != nil {
+					t.Errorf("Serve returned error: %v", serveErr)
+				}
+			case <-time.After(20 * time.Second):
+				t.Error("Serve did not return within 20s of cancellation")
+			}
+			return
+		}
+		time.Sleep(30 * time.Millisecond)
+	}
+
+	got, err := tlsPeerSerial(addr)
+	if err != nil {
+		t.Fatalf("tlsPeerSerial: %v", err)
+	}
+	t.Fatalf("certificate serial after reload = %s, want %s", got, want)
 }

--- a/internal/server/tls_integration_test.go
+++ b/internal/server/tls_integration_test.go
@@ -160,7 +160,7 @@ func overwriteSelfSignedCert(t *testing.T, certPath, keyPath string, serial int6
 }
 
 func tlsPeerSerial(addr string) (string, error) {
-	conn, err := tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12}) //nolint:gosec // test-only serial probe
+	conn, err := tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12})
 	if err != nil {
 		return "", err
 	}
@@ -345,7 +345,7 @@ func TestServer_TLSCertHotReloadWithoutRestart(t *testing.T) {
 	before := ""
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
-		conn, dialErr := tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12}) //nolint:gosec // test-only probe
+		conn, dialErr := tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12})
 		if dialErr == nil {
 			state := conn.ConnectionState()
 			if len(state.PeerCertificates) > 0 {

--- a/internal/server/tls_reload.go
+++ b/internal/server/tls_reload.go
@@ -1,0 +1,117 @@
+package server
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// certReloader serves TLS certificates via tls.Config.GetCertificate and
+// hot-reloads keypair files when either path changes on disk.
+type certReloader struct {
+	certPath string
+	keyPath  string
+	logger   *slog.Logger
+
+	mu   sync.RWMutex
+	cert *tls.Certificate
+}
+
+func newCertReloader(certPath, keyPath string, logger *slog.Logger) (*certReloader, error) {
+	r := &certReloader{
+		certPath: filepath.Clean(certPath),
+		keyPath:  filepath.Clean(keyPath),
+		logger:   logger,
+	}
+	if err := r.reload(); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func (r *certReloader) reload() error {
+	cert, err := tls.LoadX509KeyPair(r.certPath, r.keyPath)
+	if err != nil {
+		return fmt.Errorf("tls reload: load key pair: %w", err)
+	}
+	r.mu.Lock()
+	r.cert = &cert
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *certReloader) getCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	r.mu.RLock()
+	cert := r.cert
+	r.mu.RUnlock()
+	if cert == nil {
+		return nil, errors.New("tls reload: certificate not loaded")
+	}
+	return cert, nil
+}
+
+func (r *certReloader) start(ctx context.Context) (func(), error) {
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("tls reload: new watcher: %w", err)
+	}
+
+	watchDirs := map[string]struct{}{
+		filepath.Dir(r.certPath): {},
+		filepath.Dir(r.keyPath):  {},
+	}
+	for dir := range watchDirs {
+		if err := w.Add(dir); err != nil {
+			_ = w.Close()
+			return nil, fmt.Errorf("tls reload: watch %s: %w", dir, err)
+		}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case err, ok := <-w.Errors:
+				if !ok {
+					return
+				}
+				r.logger.Warn("tls reload watcher error", "error", err)
+			case event, ok := <-w.Events:
+				if !ok {
+					return
+				}
+				if !r.isWatchedPath(event.Name) {
+					continue
+				}
+				if event.Op&(fsnotify.Create|fsnotify.Write|fsnotify.Rename|fsnotify.Chmod) == 0 {
+					continue
+				}
+				if err := r.reload(); err != nil {
+					r.logger.Warn("tls reload failed", "error", err, "path", event.Name)
+					continue
+				}
+				r.logger.Info("tls certificate reloaded", "path", event.Name)
+			}
+		}
+	}()
+
+	stop := func() {
+		_ = w.Close()
+		<-done
+	}
+	return stop, nil
+}
+
+func (r *certReloader) isWatchedPath(path string) bool {
+	clean := filepath.Clean(path)
+	return clean == r.certPath || clean == r.keyPath
+}


### PR DESCRIPTION
## Summary
- hot-reload TLS certificates at runtime using a dynamic `GetCertificate` callback and file watcher
- add integration coverage for in-place certificate rotation without server restart
- extend `just tls-smoke` to rotate certs in place and assert served cert serial changes
- ensure `tls-smoke` uses `docker compose --build` to avoid stale image behavior

## Validation
- `just fmt && golangci-lint run -v ./...`
- `just tls-smoke`
- integration test includes `TestServer_TLSCertHotReloadWithoutRestart`
