### PR TITLE
fix(handlers): block private/loopback hosts in validateTargetURL

### DIFF
--- a/internal/handlers/links.go
+++ b/internal/handlers/links.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand/v2"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -834,8 +835,65 @@ func normalizeURL(target string) (string, error) {
 	return u.String(), nil
 }
 
+// privateRanges holds the CIDR blocks that must never appear as redirect
+// targets: loopback, RFC-1918 private, link-local, carrier-grade NAT, and
+// IPv6 unique-local. Initialized once at package load via an init-style
+// variable so the parse cost is paid only once.
+var privateRanges = func() []*net.IPNet {
+	cidrs := []string{
+		"127.0.0.0/8",    // IPv4 loopback
+		"::1/128",        // IPv6 loopback
+		"10.0.0.0/8",     // RFC 1918
+		"172.16.0.0/12",  // RFC 1918
+		"192.168.0.0/16", // RFC 1918
+		"169.254.0.0/16", // IPv4 link-local (APIPA / AWS IMDS)
+		"fe80::/10",      // IPv6 link-local
+		"fc00::/7",       // IPv6 unique-local (fd00::/8 is a subset)
+		"100.64.0.0/10",  // Carrier-grade NAT (RFC 6598)
+		"0.0.0.0/8",      // "This" network
+		"240.0.0.0/4",    // Reserved
+	}
+	out := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		_, ipnet, _ := net.ParseCIDR(cidr)
+		out = append(out, ipnet)
+	}
+	return out
+}()
+
+// isPrivateHost reports whether the host component of a URL (including any
+// optional port) resolves to an address that must not be used as a redirect
+// target. It blocks IP literals in private/loopback/link-local ranges and
+// the bare hostname "localhost". DNS resolution is intentionally avoided:
+// it would add per-request latency and is vulnerable to DNS rebinding; any
+// attack that requires a custom hostname is out of scope for this check.
+func isPrivateHost(host string) bool {
+	var hostname string
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		hostname = h
+	} else {
+		// SplitHostPort fails for bare IPv6 like "[::1]" (no port).
+		// Strip the brackets so net.ParseIP can handle it.
+		hostname = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
+	}
+	if strings.EqualFold(hostname, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(hostname)
+	if ip == nil {
+		return false
+	}
+	for _, block := range privateRanges {
+		if block.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
 // validateTargetURL enforces the rules the API contract advertises:
-// non-empty, length-capped, parseable, http(s) scheme, non-empty host.
+// non-empty, length-capped, parseable, http(s) scheme, non-empty host,
+// and a host that is not a private/loopback/link-local address.
 func validateTargetURL(s string) error {
 	if s == "" {
 		return errors.New("target_url is required")
@@ -852,6 +910,9 @@ func validateTargetURL(s string) error {
 	}
 	if u.Host == "" {
 		return errors.New("target_url must have a host")
+	}
+	if isPrivateHost(u.Host) {
+		return errors.New("target_url must not point to a private or internal address")
 	}
 	return nil
 }

--- a/internal/handlers/normalize_internal_test.go
+++ b/internal/handlers/normalize_internal_test.go
@@ -68,3 +68,87 @@ func TestNormalizeURL(t *testing.T) {
 		})
 	}
 }
+
+func TestIsPrivateHost(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		host    string
+		private bool
+	}{
+		// Public IPs — must pass
+		{"93.184.216.34", false},                          // example.com
+		{"2606:2800:21f:cb07:6820:80da:af6b:8b2c", false}, // example.com IPv6
+		{"93.184.216.34:80", false},                       // with port
+		{"example.com", false},                            // plain hostname
+
+		// localhost by name
+		{"localhost", true},
+		{"LOCALHOST", true},
+		{"localhost:8080", true},
+
+		// IPv4 loopback
+		{"127.0.0.1", true},
+		{"127.255.255.255", true},
+		{"127.0.0.1:5432", true},
+
+		// IPv6 loopback
+		{"::1", true},
+		{"[::1]", true},
+		{"[::1]:443", true},
+
+		// RFC 1918 private
+		{"10.0.0.1", true},
+		{"10.255.255.255", true},
+		{"172.16.0.1", true},
+		{"172.31.255.255", true},
+		{"192.168.1.1", true},
+		{"192.168.255.255", true},
+
+		// Link-local (AWS IMDS etc.)
+		{"169.254.169.254", true},
+		{"169.254.0.1", true},
+
+		// IPv6 link-local
+		{"fe80::1", true},
+
+		// IPv6 unique-local
+		{"fd00::1", true},
+		{"fc00::1", true},
+
+		// Carrier-grade NAT
+		{"100.64.0.1", true},
+		{"100.127.255.255", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.host, func(t *testing.T) {
+			t.Parallel()
+			if got := isPrivateHost(tc.host); got != tc.private {
+				t.Errorf("isPrivateHost(%q) = %v, want %v", tc.host, got, tc.private)
+			}
+		})
+	}
+}
+
+func TestValidateTargetURL_RejectsPrivateHosts(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"http://localhost/",
+		"http://127.0.0.1/",
+		"http://127.0.0.1:8080/admin",
+		"https://[::1]/",
+		"http://10.0.0.1/",
+		"http://172.16.0.1/",
+		"http://192.168.1.1/",
+		"http://169.254.169.254/latest/meta-data/",
+		"http://100.64.0.1/",
+		"http://fd00::1/",
+	}
+	for _, target := range cases {
+		t.Run(target, func(t *testing.T) {
+			t.Parallel()
+			if err := validateTargetURL(target); err == nil {
+				t.Errorf("validateTargetURL(%q) = nil, want error", target)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Prevents open-redirect abuse and pre-emptive SSRF by rejecting redirect targets whose host is a private, loopback, or link-local address.

**What is blocked:**
- `localhost` (by name, case-insensitive)
- IPv4 loopback `127.0.0.0/8`
- IPv6 loopback `::1`
- RFC 1918 private ranges (`10/8`, `172.16/12`, `192.168/16`)
- IPv4 link-local `169.254.0.0/16` (AWS IMDS / GCP metadata endpoint)
- IPv6 link-local `fe80::/10` and unique-local `fc00::/7`
- Carrier-grade NAT `100.64.0.0/10`

DNS resolution is intentionally **not** performed to avoid per-request latency and DNS-rebinding exposure. Custom internal hostnames are out of scope for this check.

**Changes:**
- `internal/handlers/links.go`: add `privateRanges` var and `isPrivateHost` helper; `validateTargetURL` now calls `isPrivateHost`
- `internal/handlers/normalize_internal_test.go`: 40+ cases covering all blocked ranges, bracket-wrapped IPv6, with-port variants, and public IPs that must still pass