### PR TITLE
fix(store): exclude expired links from list query

### DIFF
--- a/internal/handlers/links_test.go
+++ b/internal/handlers/links_test.go
@@ -126,19 +126,23 @@ func (f *fakeStore) GetLinkByTargetURL(_ context.Context, _ store.DBTX, targetUR
 
 // ListLinks returns the stored links sorted by id descending, mirroring
 // the production ordering. beforeID, when > 0, filters to ids < beforeID.
-// Soft-deleted rows are excluded so the fake matches what the SQL
-// implementation does (`WHERE deleted_at IS NULL`). When failList is
-// set, every call returns that error -- used to verify graceful
-// degradation when the database is unavailable.
+// Soft-deleted and expired rows are excluded so the fake matches what the
+// SQL implementation does. When failList is set, every call returns that
+// error -- used to verify graceful degradation when the database is
+// unavailable.
 func (f *fakeStore) ListLinks(_ context.Context, _ store.DBTX, limit int, beforeID int64) ([]store.Link, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.failList != nil {
 		return nil, f.failList
 	}
+	now := time.Now()
 	all := make([]store.Link, 0, len(f.links))
 	for _, l := range f.links {
 		if l.DeletedAt != nil {
+			continue
+		}
+		if l.ExpiresAt != nil && !l.ExpiresAt.After(now) {
 			continue
 		}
 		if beforeID > 0 && l.ID >= beforeID {
@@ -1300,6 +1304,50 @@ func TestList_ExcludesSoftDeletedRows(t *testing.T) {
 	for _, item := range resp.Items {
 		if item.Code == "remove1" {
 			t.Errorf("list returned soft-deleted code %q", item.Code)
+		}
+	}
+}
+
+func TestList_ExcludesExpiredLinks(t *testing.T) {
+	t.Parallel()
+	st, cc := newFakeStore(), newFakeCache()
+
+	past := time.Now().Add(-time.Hour)
+	future := time.Now().Add(time.Hour)
+
+	seeds := []struct {
+		code       string
+		expiresAt  *time.Time
+		wantInList bool
+	}{
+		{"exp-past", &past, false},
+		{"exp-future", &future, true},
+		{"exp-none", nil, true},
+	}
+	for _, s := range seeds {
+		if _, err := st.CreateLink(context.Background(), nil, s.code, "https://example.com/"+s.code, s.expiresAt); err != nil {
+			t.Fatalf("seed %q: %v", s.code, err)
+		}
+	}
+
+	e, _ := newHandlerWithCache(t, st, cc, &scriptedGen{})
+	rec, body := doJSON(t, e, http.MethodGet, "/api/v1/links", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, string(body))
+	}
+	resp := decodeList(t, body)
+
+	seen := make(map[string]bool, len(resp.Items))
+	for _, item := range resp.Items {
+		seen[item.Code] = true
+	}
+
+	for _, s := range seeds {
+		if s.wantInList && !seen[s.code] {
+			t.Errorf("list omitted code %q (should be present)", s.code)
+		}
+		if !s.wantInList && seen[s.code] {
+			t.Errorf("list returned code %q (should be excluded: expired)", s.code)
 		}
 	}
 }

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -278,16 +278,17 @@ func (s *Store) ListLinks(ctx context.Context, db DBTX, limit int, beforeID int6
 		rows pgx.Rows
 		err  error
 	)
-	// Soft-deleted rows are filtered out of the recent list: a
-	// retired link has no business reappearing in the public feed,
-	// and the deleted_at IS NOT NULL partial index keeps the filter
-	// cheap regardless of the deleted-row volume.
+	// Soft-deleted and expired rows are filtered out of the recent list.
+	// The deleted_at IS NOT NULL partial index keeps the deleted-row filter
+	// cheap regardless of volume; the expires_at condition uses the same
+	// index scan because expired rows are a small fraction of the table.
 	if beforeID > 0 {
 		const q = `
 			SELECT id, code, target_url, created_at, click_count, expires_at, deleted_at
 			FROM links
 			WHERE id < $1
 			  AND deleted_at IS NULL
+			  AND (expires_at IS NULL OR expires_at > NOW())
 			ORDER BY id DESC
 			LIMIT $2
 		`
@@ -297,6 +298,7 @@ func (s *Store) ListLinks(ctx context.Context, db DBTX, limit int, beforeID int6
 			SELECT id, code, target_url, created_at, click_count, expires_at, deleted_at
 			FROM links
 			WHERE deleted_at IS NULL
+			  AND (expires_at IS NULL OR expires_at > NOW())
 			ORDER BY id DESC
 			LIMIT $1
 		`

--- a/internal/store/postgres_integration_test.go
+++ b/internal/store/postgres_integration_test.go
@@ -351,3 +351,55 @@ func TestSoftDeleteLink_UnknownCodeReturnsErrNotFound(t *testing.T) {
 		t.Errorf("err = %v, want ErrNotFound", err)
 	}
 }
+
+// TestListLinks_ExcludesExpiredLinks verifies that ListLinks omits rows
+// whose expires_at is in the past while returning rows that are still
+// active (expires_at in the future) or have no expiry.
+func TestListLinks_ExcludesExpiredLinks(t *testing.T) {
+	s := newStore(t)
+	ctx := t.Context()
+
+	codeExpired := uniqueCode(t)
+	codeFuture := uniqueCode(t)
+	codeNoExpiry := uniqueCode(t)
+
+	past := time.Now().Add(-time.Hour)
+	future := time.Now().Add(time.Hour)
+
+	if _, err := s.CreateLink(ctx, nil, codeExpired, "https://example.com/expired/"+codeExpired, &past); err != nil {
+		t.Fatalf("CreateLink expired: %v", err)
+	}
+	if _, err := s.CreateLink(ctx, nil, codeFuture, "https://example.com/future/"+codeFuture, &future); err != nil {
+		t.Fatalf("CreateLink future: %v", err)
+	}
+	if _, err := s.CreateLink(ctx, nil, codeNoExpiry, "https://example.com/noexpiry/"+codeNoExpiry, nil); err != nil {
+		t.Fatalf("CreateLink noexpiry: %v", err)
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		for _, c := range []string{codeExpired, codeFuture, codeNoExpiry} {
+			_, _ = s.Pool().Exec(bg, `DELETE FROM links WHERE code = $1`, c)
+		}
+	})
+
+	// Use a large limit; rely on code membership rather than exact position.
+	rows, err := s.ListLinks(ctx, nil, 100, 0)
+	if err != nil {
+		t.Fatalf("ListLinks: %v", err)
+	}
+
+	seen := make(map[string]bool, len(rows))
+	for _, l := range rows {
+		seen[l.Code] = true
+	}
+
+	if seen[codeExpired] {
+		t.Errorf("ListLinks returned expired link (code=%q)", codeExpired)
+	}
+	if !seen[codeFuture] {
+		t.Errorf("ListLinks omitted future-expiry link (code=%q)", codeFuture)
+	}
+	if !seen[codeNoExpiry] {
+		t.Errorf("ListLinks omitted no-expiry link (code=%q)", codeNoExpiry)
+	}
+}


### PR DESCRIPTION
## Problem

`GET /api/v1/links` was returning links whose `expires_at` had already passed. The `ListLinks` SQL only filtered `deleted_at IS NULL` but had no expiry predicate.

## Changes

- **`internal/store/postgres.go`**: add `AND (expires_at IS NULL OR expires_at > NOW())` to both cursor branches of `ListLinks`
- **`internal/handlers/links_test.go`**: update `fakeStore.ListLinks` to match the same contract; add `TestList_ExcludesExpiredLinks`
- **`internal/store/postgres_integration_test.go`**: add `TestListLinks_ExcludesExpiredLinks` (requires live Postgres)

## Testing

```
go test -race ./internal/handlers/... ./internal/store/...
just lint
```