### PR TITLE
fix(server): add security response headers middleware

### DIFF
--- a/internal/server/secure.go
+++ b/internal/server/secure.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"github.com/labstack/echo/v5"
+	"github.com/labstack/echo/v5/middleware"
+)
+
+// hstsMaxAge is the Strict-Transport-Security max-age value in seconds
+// (2 years). The header is only emitted by Echo when the request
+// arrives over TLS (or with X-Forwarded-Proto: https), so this
+// constant is safe to include in the config regardless of whether the
+// deployment uses TLS.
+const hstsMaxAge = 63072000 // 2 years
+
+// buildSecureHeaders returns the Echo Secure middleware configured for
+// this service. The returned middleware always sets:
+//
+//   - X-Content-Type-Options: nosniff
+//   - X-Frame-Options: SAMEORIGIN
+//   - X-XSS-Protection: 1; mode=block
+//   - Referrer-Policy: strict-origin-when-cross-origin
+//
+// When the request arrives over HTTPS it additionally emits:
+//
+//   - Strict-Transport-Security: max-age=63072000; includeSubDomains
+func buildSecureHeaders() echo.MiddlewareFunc {
+	return middleware.SecureWithConfig(middleware.SecureConfig{
+		XSSProtection:      "1; mode=block",
+		ContentTypeNosniff: "nosniff",
+		XFrameOptions:      "SAMEORIGIN",
+		HSTSMaxAge:         hstsMaxAge,
+		ReferrerPolicy:     "strict-origin-when-cross-origin",
+	})
+}

--- a/internal/server/secure_test.go
+++ b/internal/server/secure_test.go
@@ -1,0 +1,90 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+)
+
+// newSecureEchoForTest wires the secure-headers middleware onto a stub
+// handler returning 200 so the response headers are observable.
+func newSecureEchoForTest(t *testing.T) *echo.Echo {
+	t.Helper()
+	e := echo.New()
+	e.Use(buildSecureHeaders())
+	e.GET("/", func(c *echo.Context) error { return c.NoContent(http.StatusOK) })
+	return e
+}
+
+func doPlainRequest(t *testing.T, e *echo.Echo) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestSecureHeaders_XContentTypeOptions verifies that every response
+// carries X-Content-Type-Options: nosniff to prevent MIME-type sniffing.
+func TestSecureHeaders_XContentTypeOptions(t *testing.T) {
+	t.Parallel()
+	rec := doPlainRequest(t, newSecureEchoForTest(t))
+	if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Errorf("X-Content-Type-Options = %q, want %q", got, "nosniff")
+	}
+}
+
+// TestSecureHeaders_XFrameOptions verifies that every response carries
+// X-Frame-Options: SAMEORIGIN to defend against clickjacking.
+func TestSecureHeaders_XFrameOptions(t *testing.T) {
+	t.Parallel()
+	rec := doPlainRequest(t, newSecureEchoForTest(t))
+	if got := rec.Header().Get("X-Frame-Options"); got != "SAMEORIGIN" {
+		t.Errorf("X-Frame-Options = %q, want %q", got, "SAMEORIGIN")
+	}
+}
+
+// TestSecureHeaders_ReferrerPolicy verifies the Referrer-Policy header.
+func TestSecureHeaders_ReferrerPolicy(t *testing.T) {
+	t.Parallel()
+	rec := doPlainRequest(t, newSecureEchoForTest(t))
+	want := "strict-origin-when-cross-origin"
+	if got := rec.Header().Get("Referrer-Policy"); got != want {
+		t.Errorf("Referrer-Policy = %q, want %q", got, want)
+	}
+}
+
+// TestSecureHeaders_NoHSTSOverPlainHTTP verifies that
+// Strict-Transport-Security is NOT emitted for plain HTTP requests;
+// Echo only sets it when the request is TLS or X-Forwarded-Proto: https.
+func TestSecureHeaders_NoHSTSOverPlainHTTP(t *testing.T) {
+	t.Parallel()
+	rec := doPlainRequest(t, newSecureEchoForTest(t))
+	if got := rec.Header().Get("Strict-Transport-Security"); got != "" {
+		t.Errorf("Strict-Transport-Security should be empty for HTTP, got %q", got)
+	}
+}
+
+// TestSecureHeaders_HSTSViaXForwardedProto verifies that
+// Strict-Transport-Security IS emitted when the upstream proxy signals
+// HTTPS via X-Forwarded-Proto.
+func TestSecureHeaders_HSTSViaXForwardedProto(t *testing.T) {
+	t.Parallel()
+	e := newSecureEchoForTest(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	hsts := rec.Header().Get("Strict-Transport-Security")
+	if hsts == "" {
+		t.Fatalf("Strict-Transport-Security missing for X-Forwarded-Proto: https")
+	}
+	wantPrefix := "max-age=63072000"
+	if len(hsts) < len(wantPrefix) || hsts[:len(wantPrefix)] != wantPrefix {
+		t.Errorf("Strict-Transport-Security = %q, want prefix %q", hsts, wantPrefix)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -110,6 +110,10 @@ func New(cfg config.Config, logger *slog.Logger, deps Deps) *Server {
 	// read too. Applies to every route, including the static
 	// asset handler (where bodies are always empty in practice).
 	e.Use(middleware.BodyLimit(maxRequestBodyBytes))
+	// Security headers: X-Content-Type-Options, X-Frame-Options,
+	// X-XSS-Protection, Referrer-Policy, and (for HTTPS requests)
+	// Strict-Transport-Security. Applied to every response.
+	e.Use(buildSecureHeaders())
 	// CORS is opt-in via config; no-op when CORSAllowedOrigins is
 	// empty (the default for same-origin SPA + API deployments).
 	if cors := buildCORS(cfg, logger); cors != nil {


### PR DESCRIPTION
## Problem

The server returned no security-related headers, leaving browsers without clickjacking protection, MIME-sniffing guards, or HSTS enforcement.

## Changes

- **`internal/server/secure.go`**: `buildSecureHeaders()` helper wrapping Echo's `SecureWithConfig`; sets `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Referrer-Policy`, and `Strict-Transport-Security` (HTTPS only)
- **`internal/server/server.go`**: mount `buildSecureHeaders()` after `BodyLimit`, before CORS
- **`internal/server/secure_test.go`**: unit tests for each header including the conditional HSTS behaviour over plain HTTP vs `X-Forwarded-Proto: https`

## Testing

```
go test -race ./internal/server/...
just lint
```