### PR TITLE
fix(handlers): use ErrorResponse schema in redirect error paths

### DIFF
--- a/internal/handlers/links.go
+++ b/internal/handlers/links.go
@@ -579,7 +579,7 @@ func (h *Links) Delete(c *echo.Context) error {
 func (h *Links) Redirect(c *echo.Context) error {
 	code := c.Param("code")
 	if !shortener.ValidCode(code) {
-		return echo.NewHTTPError(http.StatusNotFound, "not found")
+		return c.JSON(http.StatusNotFound, errResp(ErrCodeNotFound, "not found"))
 	}
 	ctx := c.Request().Context()
 
@@ -590,7 +590,7 @@ func (h *Links) Redirect(c *echo.Context) error {
 		// 410) isn't preserved because the public response surface
 		// for both is the same as far as a redirect client is
 		// concerned: there is nothing here to redirect to.
-		return echo.NewHTTPError(http.StatusNotFound, "not found")
+		return c.JSON(http.StatusNotFound, errResp(ErrCodeNotFound, "not found"))
 	case hit:
 		h.recordClick(code)
 		return c.Redirect(http.StatusFound, target)
@@ -599,19 +599,19 @@ func (h *Links) Redirect(c *echo.Context) error {
 	link, err := h.store.GetLinkByCode(ctx, nil, code)
 	if errors.Is(err, store.ErrNotFound) {
 		h.cachePutNegative(ctx, code)
-		return echo.NewHTTPError(http.StatusNotFound, "not found")
+		return c.JSON(http.StatusNotFound, errResp(ErrCodeNotFound, "not found"))
 	}
 	if err != nil {
 		h.logger.Error("links: redirect lookup failed", "error", err, "code", code)
-		return echo.NewHTTPError(http.StatusInternalServerError, "internal error")
+		return c.JSON(http.StatusInternalServerError, errResp(ErrCodeInternal, "internal error"))
 	}
 	if link.IsDeleted() {
 		h.cachePutNegative(ctx, code)
-		return echo.NewHTTPError(http.StatusGone, "link has been deleted")
+		return c.JSON(http.StatusGone, errResp(ErrCodeLinkDeleted, "link has been deleted"))
 	}
 	if link.IsExpired() {
 		h.cachePutNegative(ctx, code)
-		return echo.NewHTTPError(http.StatusGone, "link has expired")
+		return c.JSON(http.StatusGone, errResp(ErrCodeLinkExpired, "link has expired"))
 	}
 
 	h.cachePut(ctx, link)

--- a/internal/handlers/links_test.go
+++ b/internal/handlers/links_test.go
@@ -801,6 +801,92 @@ func TestRedirect_ExpiredLinkReturns410(t *testing.T) {
 	}
 }
 
+// TestRedirect_ErrorsUseErrorResponseSchema verifies that 4xx/5xx
+// responses from the redirect handler use the same
+// {"error":"...","code":"..."} JSON shape as every other handler,
+// rather than Echo's default {"message":"..."} envelope.
+func TestRedirect_ErrorsUseErrorResponseSchema(t *testing.T) {
+	t.Parallel()
+
+	past := time.Now().Add(-time.Hour)
+	future := time.Now().Add(time.Hour)
+
+	cases := []struct {
+		name      string
+		path      string
+		seed      func(*fakeStore)
+		wantCode  int
+		wantECode string
+	}{
+		{
+			name:      "unknown code returns not_found",
+			path:      "/r/missing1",
+			wantCode:  http.StatusNotFound,
+			wantECode: handlers.ErrCodeNotFound,
+		},
+		{
+			name: "deleted link returns link_deleted",
+			path: "/r/deldlink",
+			seed: func(st *fakeStore) {
+				_, _ = st.CreateLink(context.Background(), nil, "deldlink", "https://del.example", nil)
+				_ = st.SoftDeleteLink(context.Background(), nil, "deldlink")
+			},
+			wantCode:  http.StatusGone,
+			wantECode: handlers.ErrCodeLinkDeleted,
+		},
+		{
+			name: "expired link returns link_expired",
+			path: "/r/exprlnk",
+			seed: func(st *fakeStore) {
+				_, _ = st.CreateLink(context.Background(), nil, "exprlnk", "https://exp.example", &past)
+			},
+			wantCode:  http.StatusGone,
+			wantECode: handlers.ErrCodeLinkExpired,
+		},
+		{
+			name: "negative cache hit returns not_found",
+			path: "/r/ncached",
+			seed: func(st *fakeStore) {
+				// Prime a future-expiry link so it exists in the store,
+				// then seed the negative-cache sentinel to short-circuit.
+				_, _ = st.CreateLink(context.Background(), nil, "ncached", "https://nc.example", &future)
+			},
+			wantCode:  http.StatusNotFound,
+			wantECode: handlers.ErrCodeNotFound,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			st, cc := newFakeStore(), newFakeCache()
+			if tc.seed != nil {
+				tc.seed(st)
+			}
+			// For the negative-cache case, manually seed the sentinel.
+			if tc.wantECode == handlers.ErrCodeNotFound && tc.name == "negative cache hit returns not_found" {
+				_ = cc.Set(context.Background(), "link:ncached", "", time.Minute)
+			}
+			e, _ := newHandlerWithCache(t, st, cc, &scriptedGen{})
+
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.wantCode)
+			}
+			got := decodeError(t, rec.Body.Bytes())
+			if got.Code != tc.wantECode {
+				t.Errorf("error code = %q, want %q", got.Code, tc.wantECode)
+			}
+			if got.Error == "" {
+				t.Errorf("error message is empty")
+			}
+		})
+	}
+}
+
 // TestGet_ExpiredLinkReturns410: same shape as the redirect, exposed
 // via the JSON API so a programmatic client can distinguish a
 // once-valid code from an unknown one.


### PR DESCRIPTION
## Problem

The `Redirect` handler returned errors via `echo.NewHTTPError(status, "plain string")`, which produces Echo's default `{"message":"..."}` envelope. Every other handler in the service returns `{"error":"...","code":"..."}" via `errResp()`. This inconsistency makes programmatic clients (and the OpenAPI contract) untrustworthy for redirect errors.

## Changes

- **`internal/handlers/links.go`**: replace all five `echo.NewHTTPError` calls in `Redirect` with `c.JSON(status, errResp(errCode, message))`, using the existing `ErrCodeNotFound`, `ErrCodeLinkDeleted`, `ErrCodeLinkExpired`, and `ErrCodeInternal` constants
- **`internal/handlers/links_test.go`**: add `TestRedirect_ErrorsUseErrorResponseSchema` — table-driven, covering 404 (unknown), 410 (deleted), 410 (expired), and 404 (negative-cache hit)

## Testing

```
go test -race ./internal/handlers/...
just lint
```