### PR TITLE
fix(server): log User-Agent header in request logger

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -310,6 +310,7 @@ func slogRequestLogger(logger *slog.Logger) echo.MiddlewareFunc {
 		LogLatency:   true,
 		LogRequestID: true,
 		LogRemoteIP:  true,
+		LogUserAgent: true,
 		HandleError:  true,
 		LogValuesFunc: func(c *echo.Context, v middleware.RequestLoggerValues) error {
 			level := slog.LevelInfo
@@ -327,6 +328,7 @@ func slogRequestLogger(logger *slog.Logger) echo.MiddlewareFunc {
 				"latency_ms", v.Latency.Milliseconds(),
 				"request_id", v.RequestID,
 				"remote_ip", v.RemoteIP,
+				"user_agent", v.UserAgent,
 			}
 			if v.Error != nil {
 				attrs = append(attrs, "error", v.Error.Error())


### PR DESCRIPTION
## Problem

The request logger emitted method, URI, status, latency, request ID, and remote IP — but not the client's `User-Agent`. This makes it harder to distinguish bots, browser traffic, and API clients in production logs.

## Change

- **`internal/server/server.go`**: add `LogUserAgent: true` to `RequestLoggerConfig` and append `"user_agent", v.UserAgent` to the slog attributes slice

## Testing

```
go build ./...
just lint
```