### PR TITLE
test(handlers): add seedCache field to TestRedirect_ErrorsUseErrorResponseSchema

### DIFF
--- a/internal/handlers/links_test.go
+++ b/internal/handlers/links_test.go
@@ -856,6 +856,7 @@ func TestRedirect_ErrorsUseErrorResponseSchema(t *testing.T) {
 		name      string
 		path      string
 		seed      func(*fakeStore)
+		seedCache func(*fakeCache)
 		wantCode  int
 		wantECode string
 	}{
@@ -892,6 +893,9 @@ func TestRedirect_ErrorsUseErrorResponseSchema(t *testing.T) {
 				// then seed the negative-cache sentinel to short-circuit.
 				_, _ = st.CreateLink(context.Background(), nil, "ncached", "https://nc.example", &future)
 			},
+			seedCache: func(cc *fakeCache) {
+				_ = cc.Set(context.Background(), "link:ncached", "", time.Minute)
+			},
 			wantCode:  http.StatusNotFound,
 			wantECode: handlers.ErrCodeNotFound,
 		},
@@ -904,9 +908,8 @@ func TestRedirect_ErrorsUseErrorResponseSchema(t *testing.T) {
 			if tc.seed != nil {
 				tc.seed(st)
 			}
-			// For the negative-cache case, manually seed the sentinel.
-			if tc.wantECode == handlers.ErrCodeNotFound && tc.name == "negative cache hit returns not_found" {
-				_ = cc.Set(context.Background(), "link:ncached", "", time.Minute)
+			if tc.seedCache != nil {
+				tc.seedCache(cc)
 			}
 			e, _ := newHandlerWithCache(t, st, cc, &scriptedGen{})
 


### PR DESCRIPTION
The loop body previously identified the negative-cache case by name to
seed the cache sentinel, coupling the test logic to a magic string:

```go
if tc.wantECode == handlers.ErrCodeNotFound && tc.name == "negative cache hit returns not_found" {
    _ = cc.Set(...)
}
```

Add a `seedCache func(*fakeCache)` field to the case struct, parallel to
the existing `seed func(*fakeStore)`. The negative-cache case now carries
its own setup inline; the loop body shrinks to a single nil-guard:

```go
if tc.seedCache != nil { tc.seedCache(cc) }
```

Future cases that need a pre-seeded cache can now express that
without touching the loop body.