### PR TITLE
test(handlers): collapse newHandlerWithCache to delegate to newHandlerWithTTLs

### DIFF
--- a/internal/handlers/links_test.go
+++ b/internal/handlers/links_test.go
@@ -238,15 +238,7 @@ const baseURL = "https://short.test"
 
 func newHandlerWithCache(t *testing.T, st handlers.LinkStore, cc handlers.LinkCache, gen handlers.Generator) (*echo.Echo, *handlers.Links) {
 	t.Helper()
-	h := handlers.NewLinks(handlers.LinksConfig{
-		Store:     st,
-		Cache:     cc,
-		Generator: gen,
-		BaseURL:   baseURL,
-	})
-	e := echo.New()
-	h.Mount(e)
-	return e, h
+	return newHandlerWithTTLs(t, st, cc, gen, 0, 0)
 }
 
 func newHandlerWithTTLs(


### PR DESCRIPTION
The two helpers were near-identical: `newHandlerWithCache` built a `Links`
handler with no TTL overrides; `newHandlerWithTTLs` did the same plus
`CacheTTL`/`NegativeCacheTTL`. Any change to the shared wiring (`BaseURL`,
`Mount`, etc.) had to be applied in both places.

Reduce to a single source of truth by making `newHandlerWithCache` a
one-liner that calls `newHandlerWithTTLs` with zero TTLs (which `NewLinks`
already maps to the package-level defaults):

```go
func newHandlerWithCache(t *testing.T, st handlers.LinkStore, cc handlers.LinkCache, gen handlers.Generator) (*echo.Echo, *handlers.Links) {
    t.Helper()
    return newHandlerWithTTLs(t, st, cc, gen, 0, 0)
}
```