### PR TITLE
docs(store): clarify nil-means-pool convention on DBTX and LinkStore

### DIFF
--- a/internal/handlers/links.go
+++ b/internal/handlers/links.go
@@ -76,6 +76,11 @@ const (
 
 // LinkStore is the storage surface the links handler depends on. It is
 // satisfied by *store.Store; tests use a fake implementation.
+//
+// The db parameter on every method follows the nil-means-pool convention
+// defined on store.DBTX: pass nil for standalone operations (all current
+// call sites do this) and a live *pgx.Tx only when multiple operations
+// must share a transaction.
 type LinkStore interface {
 	CreateLink(ctx context.Context, db store.DBTX, code, targetURL string, expiresAt *time.Time) (store.Link, error)
 	GetLinkByCode(ctx context.Context, db store.DBTX, code string) (store.Link, error)

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -77,6 +77,11 @@ func IsTransient(err error) bool {
 
 // DBTX is satisfied by *pgxpool.Pool (and pgxpool.Conn) as well as pgx.Tx,
 // allowing store methods to participate in caller-managed transactions.
+//
+// Convention: pass nil to use the store's own connection pool (the common
+// case -- every current call site does this). Pass a *pgx.Tx obtained from
+// s.Pool().Begin() only when multiple store operations must be atomic; each
+// method checks for nil and falls back to s.pool automatically.
 type DBTX interface {
 	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
 	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)


### PR DESCRIPTION
Every call site passes `nil` for the `db` parameter on store methods,
which each method silently maps to `s.pool`. Without documentation this
reads as dead-weight API surface — a parameter that is always `nil` —
and obscures why the parameter exists at all.

Add a short convention note to `DBTX` (the canonical definition in `store/postgres.go`)
and a cross-reference on `LinkStore` (the handlers-facing copy in `handlers/links.go`):

- `nil` is the normal case: use the store's own pool (all current call sites)
- a live `*pgx.Tx` is passed only when multiple operations must be atomic
- each store method already handles the `nil` fallback automatically