### PR TITLE
refactor(handlers): remove retries field, inline CreateMaxRetries constant

### DIFF
--- a/internal/handlers/links.go
+++ b/internal/handlers/links.go
@@ -116,7 +116,6 @@ type Links struct {
 	logger      *slog.Logger
 	cacheTTL    time.Duration
 	negCacheTTL time.Duration
-	retries     int
 
 	// bgWG tracks fire-and-forget goroutines (currently just the
 	// click-increment background work). Tests use
@@ -163,7 +162,6 @@ func NewLinks(cfg LinksConfig) *Links {
 		logger:      logger,
 		cacheTTL:    cacheTTL,
 		negCacheTTL: negCacheTTL,
-		retries:     CreateMaxRetries,
 	}
 }
 

--- a/internal/handlers/links_service.go
+++ b/internal/handlers/links_service.go
@@ -143,7 +143,7 @@ func (h *Links) listPage(ctx context.Context, pageSize int, beforeID int64) ([]s
 // implies either an exhausted keyspace or a degenerate generator and
 // should surface as a 500.
 func (h *Links) createWithRandomCode(ctx context.Context, target string, expiresAt *time.Time) (store.Link, error) {
-	for i := 0; i < h.retries; i++ {
+	for i := 0; i < CreateMaxRetries; i++ {
 		code, err := h.gen.Generate()
 		if err != nil {
 			return store.Link{}, fmt.Errorf("generate code: %w", err)
@@ -155,7 +155,7 @@ func (h *Links) createWithRandomCode(ctx context.Context, target string, expires
 		}
 		return l, err
 	}
-	return store.Link{}, fmt.Errorf("failed to generate unique code after %d attempts", h.retries)
+	return store.Link{}, fmt.Errorf("failed to generate unique code after %d attempts", CreateMaxRetries)
 }
 
 // validateExpiresAt enforces that an explicit expiry is in the future


### PR DESCRIPTION
`Links.retries` was set unconditionally to `CreateMaxRetries` in `NewLinks` and never overridden — `LinksConfig` had no `Retries` knob, so no caller could change it. The field existed in the struct but provided no configurability over using the constant directly.

**Before:**
```go
type Links struct {
    ...
    retries int
}

func NewLinks(cfg LinksConfig) *Links {
    ...
    retries: CreateMaxRetries,
}

for i := 0; i < h.retries; i++ {
```

**After:**
```go
type Links struct {
    // retries field removed
}

for i := 0; i < CreateMaxRetries; i++ {
```

If per-instance retry override is needed in the future it can be added to `LinksConfig` at that point.