### PR TITLE
test: fail fast when required integration test env vars are unset

### DIFF
--- a/internal/cache/redis_integration_test.go
+++ b/internal/cache/redis_integration_test.go
@@ -21,7 +21,7 @@ func newClient(t *testing.T) *cache.Client {
 	t.Helper()
 	url := os.Getenv("URL_SHORTENER_TEST_REDIS_URL")
 	if url == "" {
-		t.Skip("URL_SHORTENER_TEST_REDIS_URL not set; skipping integration test")
+		t.Fatal("URL_SHORTENER_TEST_REDIS_URL must be set to run integration tests")
 	}
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()

--- a/internal/migrate/versions_integration_test.go
+++ b/internal/migrate/versions_integration_test.go
@@ -15,7 +15,7 @@ func testDatabaseURL(t *testing.T) string {
 	t.Helper()
 	url := os.Getenv("URL_SHORTENER_TEST_DATABASE_URL")
 	if url == "" {
-		t.Skip("URL_SHORTENER_TEST_DATABASE_URL not set; skipping integration test")
+		t.Fatal("URL_SHORTENER_TEST_DATABASE_URL must be set to run integration tests")
 	}
 	return url
 }

--- a/internal/server/links_integration_test.go
+++ b/internal/server/links_integration_test.go
@@ -53,11 +53,11 @@ func startFullServerWithDeps(t *testing.T) (string, *store.Store, *cache.Client,
 
 	dbURL := os.Getenv("URL_SHORTENER_TEST_DATABASE_URL")
 	if dbURL == "" {
-		t.Skip("URL_SHORTENER_TEST_DATABASE_URL not set; skipping integration test")
+		t.Fatal("URL_SHORTENER_TEST_DATABASE_URL must be set to run integration tests")
 	}
 	redisURL := os.Getenv("URL_SHORTENER_TEST_REDIS_URL")
 	if redisURL == "" {
-		t.Skip("URL_SHORTENER_TEST_REDIS_URL not set; skipping integration test")
+		t.Fatal("URL_SHORTENER_TEST_REDIS_URL must be set to run integration tests")
 	}
 
 	ctx := t.Context()
@@ -383,11 +383,11 @@ func TestLinksAPI_UnknownCodeReturns404(t *testing.T) {
 func TestServer_GracefulShutdownDrainsBackgroundTasks(t *testing.T) {
 	dbURL := os.Getenv("URL_SHORTENER_TEST_DATABASE_URL")
 	if dbURL == "" {
-		t.Skip("URL_SHORTENER_TEST_DATABASE_URL not set; skipping integration test")
+		t.Fatal("URL_SHORTENER_TEST_DATABASE_URL must be set to run integration tests")
 	}
 	redisURL := os.Getenv("URL_SHORTENER_TEST_REDIS_URL")
 	if redisURL == "" {
-		t.Skip("URL_SHORTENER_TEST_REDIS_URL not set; skipping integration test")
+		t.Fatal("URL_SHORTENER_TEST_REDIS_URL must be set to run integration tests")
 	}
 
 	ctx := t.Context()

--- a/internal/server/tls_integration_test.go
+++ b/internal/server/tls_integration_test.go
@@ -175,8 +175,11 @@ func tlsPeerSerial(addr string) (string, error) {
 func TestServer_TLSListenerServesHTTPS(t *testing.T) {
 	dbURL := os.Getenv("URL_SHORTENER_TEST_DATABASE_URL")
 	redisURL := os.Getenv("URL_SHORTENER_TEST_REDIS_URL")
-	if dbURL == "" || redisURL == "" {
-		t.Skip("URL_SHORTENER_TEST_DATABASE_URL / URL_SHORTENER_TEST_REDIS_URL not set; skipping integration test")
+	if dbURL == "" {
+		t.Fatal("URL_SHORTENER_TEST_DATABASE_URL must be set to run integration tests")
+	}
+	if redisURL == "" {
+		t.Fatal("URL_SHORTENER_TEST_REDIS_URL must be set to run integration tests")
 	}
 
 	certPath, keyPath := generateSelfSignedCert(t, t.TempDir())
@@ -295,8 +298,11 @@ func TestServer_TLSListenerServesHTTPS(t *testing.T) {
 func TestServer_TLSCertHotReloadWithoutRestart(t *testing.T) {
 	dbURL := os.Getenv("URL_SHORTENER_TEST_DATABASE_URL")
 	redisURL := os.Getenv("URL_SHORTENER_TEST_REDIS_URL")
-	if dbURL == "" || redisURL == "" {
-		t.Skip("URL_SHORTENER_TEST_DATABASE_URL / URL_SHORTENER_TEST_REDIS_URL not set; skipping integration test")
+	if dbURL == "" {
+		t.Fatal("URL_SHORTENER_TEST_DATABASE_URL must be set to run integration tests")
+	}
+	if redisURL == "" {
+		t.Fatal("URL_SHORTENER_TEST_REDIS_URL must be set to run integration tests")
 	}
 
 	certPath, keyPath := generateSelfSignedCert(t, t.TempDir())

--- a/internal/store/postgres_integration_test.go
+++ b/internal/store/postgres_integration_test.go
@@ -27,7 +27,7 @@ func newStore(t *testing.T) *store.Store {
 	t.Helper()
 	url := os.Getenv("URL_SHORTENER_TEST_DATABASE_URL")
 	if url == "" {
-		t.Skip("URL_SHORTENER_TEST_DATABASE_URL not set; skipping integration test")
+		t.Fatal("URL_SHORTENER_TEST_DATABASE_URL must be set to run integration tests")
 	}
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()


### PR DESCRIPTION
The integration tests previously called `t.Skip` when `URL_SHORTENER_TEST_DATABASE_URL` or `URL_SHORTENER_TEST_REDIS_URL` were missing. A skip looks like a passing run in most CI UIs and can silently mask a misconfigured test environment.

Replace every `t.Skip` with `t.Fatal` across all 5 integration test files so a missing env var surfaces as a clear failure rather than a quiet skip.

Integration tests are gated behind the `integration` build tag, so this only affects `just test-integration` runs — the unit test suite is unchanged.