### PR TITLE
test(handlers): document fakeStore.GetLinkByCode expiry/deletion asymmetry

### DIFF
--- a/internal/handlers/links_test.go
+++ b/internal/handlers/links_test.go
@@ -89,6 +89,12 @@ func (f *fakeStore) IncrementClicks(_ context.Context, _ store.DBTX, code string
 	return nil
 }
 
+// GetLinkByCode returns the stored link regardless of expiry or deletion,
+// mirroring the production store which also returns any row (even
+// soft-deleted or expired ones). The handler is responsible for calling
+// link.IsExpired() / link.IsDeleted() and mapping those to 410 Gone.
+// Contrast with ListLinks below, which filters both conditions at the
+// store level matching the SQL WHERE clause.
 func (f *fakeStore) GetLinkByCode(_ context.Context, _ store.DBTX, code string) (store.Link, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()


### PR DESCRIPTION
`GetLinkByCode` returned every row regardless of `expires_at` or `deleted_at` — matching the production store — but without a comment this reads as a missing filter.

Add a doc comment explaining the deliberate asymmetry:

- `GetLinkByCode` (fake and real) returns the raw row; the **handler** calls `link.IsExpired()` / `link.IsDeleted()` and maps those to 410 Gone
- `ListLinks` is intentionally different: it filters both conditions at the **store** level (SQL `WHERE` clause), so the fake also filters there