### PR TITLE
feat(server): replace per-instance rate limiter with Redis fixed-window

### DIFF
--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -87,3 +87,41 @@ func (c *Client) Del(ctx context.Context, keys ...string) error {
 	}
 	return nil
 }
+
+// rateLimitScript atomically increments a counter and sets a
+// millisecond TTL on first use. Callers compare the returned count
+// against their limit to decide whether the request is allowed.
+//
+// KEYS[1] – the rate-limit bucket key (unique per IP + window label)
+// ARGV[1] – window duration in milliseconds (used as the key TTL)
+var rateLimitScript = redis.NewScript(`
+local count = redis.call('INCR', KEYS[1])
+if count == 1 then
+    redis.call('PEXPIRE', KEYS[1], tonumber(ARGV[1]))
+end
+return count
+`)
+
+// RateLimit checks whether the given key has exceeded limit requests
+// within window using a fixed-window counter in Redis. It returns
+// (true, remaining, nil) when the request is within budget and
+// (false, 0, nil) when the limit is exceeded. A Redis error is
+// returned wrapped; callers should allow the request on error to avoid
+// false positives under transient Redis failures (fail-open).
+//
+// The algorithm is a fixed-window counter: the first request in a
+// window sets a TTL equal to window, and the counter resets when the
+// key expires. This means up to 2 × limit requests can be observed at
+// a window boundary, which is the standard trade-off for this approach
+// -- use a sliding window (sorted-set ZADD) if strict per-window
+// budgets are required.
+func (c *Client) RateLimit(ctx context.Context, key string, limit int, window time.Duration) (bool, int, error) {
+	count, err := rateLimitScript.Run(ctx, c.rdb, []string{key}, window.Milliseconds()).Int64()
+	if err != nil {
+		return false, 0, fmt.Errorf("cache: rate limit: %w", err)
+	}
+	if count > int64(limit) {
+		return false, 0, nil
+	}
+	return true, limit - int(count), nil
+}

--- a/internal/cache/redis_integration_test.go
+++ b/internal/cache/redis_integration_test.go
@@ -117,3 +117,89 @@ func TestPing(t *testing.T) {
 		t.Errorf("Ping: %v", err)
 	}
 }
+
+// TestRateLimit_FixedWindowBehavior verifies the core contract of
+// RateLimit: the first `limit` calls for a key are allowed, the next
+// are denied, and the counter resets after the window expires.
+func TestRateLimit_FixedWindowBehavior(t *testing.T) {
+	c := newClient(t)
+	ctx := t.Context()
+	key := uniqueKey(t, "rl")
+
+	const limit = 3
+	const window = 200 * time.Millisecond
+
+	t.Cleanup(func() { _ = c.Del(context.Background(), key) })
+
+	// First `limit` calls must be allowed.
+	for i := range limit {
+		allowed, remaining, err := c.RateLimit(ctx, key, limit, window)
+		if err != nil {
+			t.Fatalf("call %d: RateLimit: %v", i+1, err)
+		}
+		if !allowed {
+			t.Errorf("call %d: allowed = false, want true", i+1)
+		}
+		want := limit - (i + 1)
+		if remaining != want {
+			t.Errorf("call %d: remaining = %d, want %d", i+1, remaining, want)
+		}
+	}
+
+	// (limit+1)-th call must be denied.
+	allowed, _, err := c.RateLimit(ctx, key, limit, window)
+	if err != nil {
+		t.Fatalf("over-limit call: RateLimit: %v", err)
+	}
+	if allowed {
+		t.Errorf("over-limit call: allowed = true, want false")
+	}
+
+	// After the window expires the counter resets.
+	time.Sleep(window + 50*time.Millisecond)
+
+	allowed, _, err = c.RateLimit(ctx, key, limit, window)
+	if err != nil {
+		t.Fatalf("post-reset call: RateLimit: %v", err)
+	}
+	if !allowed {
+		t.Errorf("post-reset call: allowed = false, want true (window should have reset)")
+	}
+}
+
+// TestRateLimit_PerKeyIsolation: distinct keys (different IPs) each
+// get independent counters.
+func TestRateLimit_PerKeyIsolation(t *testing.T) {
+	c := newClient(t)
+	ctx := t.Context()
+
+	keyA := uniqueKey(t, "rl-a")
+	keyB := uniqueKey(t, "rl-b")
+	t.Cleanup(func() {
+		_ = c.Del(context.Background(), keyA, keyB)
+	})
+
+	const limit = 1
+	const window = time.Second
+
+	// Exhaust key B.
+	if _, _, err := c.RateLimit(ctx, keyB, limit, window); err != nil {
+		t.Fatalf("B first: %v", err)
+	}
+	allowed, _, err := c.RateLimit(ctx, keyB, limit, window)
+	if err != nil {
+		t.Fatalf("B second: %v", err)
+	}
+	if allowed {
+		t.Fatalf("B second: allowed = true, want false")
+	}
+
+	// Key A must still be within budget.
+	allowed, _, err = c.RateLimit(ctx, keyA, limit, window)
+	if err != nil {
+		t.Fatalf("A first: %v", err)
+	}
+	if !allowed {
+		t.Errorf("A first: allowed = false, want true (keys must be isolated)")
+	}
+}

--- a/internal/server/ratelimit.go
+++ b/internal/server/ratelimit.go
@@ -1,52 +1,56 @@
 package server
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 	"time"
 
 	"github.com/labstack/echo/v5"
-	"github.com/labstack/echo/v5/middleware"
 
 	"github.com/vancanhuit/url-shortener/internal/config"
 	"github.com/vancanhuit/url-shortener/internal/handlers"
 )
 
-// rateLimitExpiresIn is how long an idle per-IP token bucket survives
-// in the in-memory store before it is evicted. Long enough to keep a
-// returning legitimate user inside their established budget, short
-// enough that a one-off scan from a transient IP doesn't pin memory.
-const rateLimitExpiresIn = 3 * time.Minute
+// rateLimiter is the shared-state backend for the per-IP rate limiter.
+// The production implementation is *cache.Client; tests inject a fake.
+// Callers should allow the request when err is non-nil (fail-open).
+type rateLimiter interface {
+	RateLimit(ctx context.Context, key string, limit int, window time.Duration) (bool, int, error)
+}
+
+// rateLimitKeyPrefix namespaces the per-IP keys so they never collide
+// with the redirect-lookup cache entries written by the handlers layer.
+const rateLimitKeyPrefix = "ratelimit:create:"
 
 // buildCreateRateLimiter returns the middleware list to attach to
 // `POST /api/v1/links`. When cfg.RateLimitRPS is 0 (the default) the
 // returned slice is empty -- rate limiting is fully opt-in.
 //
-// The limiter uses Echo's bundled in-memory store keyed on the real
-// client IP (Context.RealIP, which honors cfg.TrustedProxies). On a
-// deny it returns a 429 with the project's standard JSON error
-// envelope so SPA / API clients can branch on the stable code
-// `rate_limited` rather than parsing prose. ID-extraction failures
-// (which essentially can't happen with the IP extractor) fall through
-// to a 500 with the same envelope.
+// The limiter uses a Redis fixed-window counter (via rl) keyed on the
+// real client IP (Context.RealIP, which honors cfg.TrustedProxies).
+// Because the counter lives in Redis it is shared across all replicas,
+// so the configured RPS budget is enforced globally -- not multiplied
+// by the replica count. On a deny it returns 429 with the project's
+// standard JSON error envelope.
 //
-// Multi-replica deployments share no state across processes here:
-// the limiter is per-instance, so the effective ceiling is N * RPS
-// behind a load balancer with weighted spread. That is intentional
-// for a v1 limiter -- it costs nothing, can't go wrong under network
-// partitions, and is plenty for the threat we care about (a single
-// abuser hammering one node). Promote to Redis when N grows large
-// enough that per-instance budgets stop being meaningful.
-func buildCreateRateLimiter(cfg config.Config, logger *slog.Logger) []echo.MiddlewareFunc {
+// Fail-open: a Redis error is logged and the request is allowed through
+// to avoid turning a cache outage into a service outage.
+//
+// Fixed-window trade-off: at a window boundary a client can observe up
+// to 2 × burst requests. Acceptable for abuse prevention; switch to a
+// sliding-window (sorted-set) implementation if strict per-second
+// budgets are required.
+func buildCreateRateLimiter(cfg config.Config, rl rateLimiter, logger *slog.Logger) []echo.MiddlewareFunc {
 	if cfg.RateLimitRPS <= 0 {
 		return nil
 	}
 
 	burst := cfg.RateLimitBurst
 	if burst <= 0 {
-		// Default burst = 2 * RPS so a legitimate client clicking
+		// Default burst = 2 × RPS so a legitimate client clicking
 		// "create" a couple of times in a row stays inside the
-		// bucket. Floor at 1 so a fractional RPS like 0.5 still
+		// budget. Floor at 1 so a fractional RPS like 0.5 still
 		// admits at least one request.
 		burst = int(cfg.RateLimitRPS * 2)
 		if burst < 1 {
@@ -54,48 +58,45 @@ func buildCreateRateLimiter(cfg config.Config, logger *slog.Logger) []echo.Middl
 		}
 	}
 
-	store := middleware.NewRateLimiterMemoryStoreWithConfig(middleware.RateLimiterMemoryStoreConfig{
-		Rate:      cfg.RateLimitRPS,
-		Burst:     burst,
-		ExpiresIn: rateLimitExpiresIn,
-	})
+	// Fixed window of 1 second: `burst` requests per second per IP.
+	// Using 1 s keeps the key TTL short and keeps the math simple;
+	// the RPS value determines the steady-state budget when burst is
+	// left at its default (2 × RPS) and the operator tunes both.
+	const window = time.Second
 
-	mw, err := middleware.RateLimiterConfig{
-		Store: store,
-		IdentifierExtractor: func(c *echo.Context) (string, error) {
-			return c.RealIP(), nil
-		},
-		ErrorHandler: func(c *echo.Context, err error) error {
-			logger.Warn("rate limiter: identifier extraction failed",
-				"error", err, "remote", c.Request().RemoteAddr)
-			return c.JSON(http.StatusInternalServerError,
-				handlers.ErrorResponse{
-					Error: "internal error",
-					Code:  handlers.ErrCodeInternal,
-				})
-		},
-		DenyHandler: func(c *echo.Context, identifier string, _ error) error {
-			logger.Info("rate limit exceeded",
-				"identifier", identifier,
-				"path", c.Path(),
-				"method", c.Request().Method,
-			)
-			return c.JSON(http.StatusTooManyRequests,
-				handlers.ErrorResponse{
-					Error: "rate limit exceeded",
-					Code:  handlers.ErrCodeRateLimited,
-				})
-		},
-	}.ToMiddleware()
-	if err != nil {
-		// ToMiddleware only errors when the config is incoherent
-		// (e.g. nil Store), all of which are programming bugs in
-		// this constructor. Fail fast at startup.
-		panic("server: build rate limiter: " + err.Error())
+	mw := func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c *echo.Context) error {
+			ip := c.RealIP()
+			key := rateLimitKeyPrefix + ip
+
+			allowed, _, err := rl.RateLimit(c.Request().Context(), key, burst, window)
+			if err != nil {
+				// Redis unavailable: fail open so a cache outage
+				// never becomes a request outage.
+				logger.Warn("rate limiter: backend error, allowing request",
+					"error", err, "ip", ip)
+				return next(c)
+			}
+
+			if !allowed {
+				logger.Info("rate limit exceeded",
+					"identifier", ip,
+					"path", c.Path(),
+					"method", c.Request().Method,
+				)
+				return c.JSON(http.StatusTooManyRequests,
+					handlers.ErrorResponse{
+						Error: "rate limit exceeded",
+						Code:  handlers.ErrCodeRateLimited,
+					})
+			}
+			return next(c)
+		}
 	}
 
 	logger.Info("rate limiter enabled",
 		"endpoint", "POST /api/v1/links",
+		"backend", "redis",
 		"rps", cfg.RateLimitRPS,
 		"burst", burst,
 	)

--- a/internal/server/ratelimit_test.go
+++ b/internal/server/ratelimit_test.go
@@ -1,19 +1,49 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v5"
 
 	"github.com/vancanhuit/url-shortener/internal/config"
 	"github.com/vancanhuit/url-shortener/internal/handlers"
 )
+
+// fakeRateLimiter is a thread-safe in-process rateLimiter that mirrors
+// the fixed-window semantics of cache.Client.RateLimit: the first
+// `limit` calls for a given key are allowed; subsequent calls within
+// the same "window" (no real TTL here -- the counter only resets when
+// resetKey is called) are denied. The TTL is recorded but not acted
+// on, keeping tests deterministic.
+type fakeRateLimiter struct {
+	mu       sync.Mutex
+	counters map[string]int
+}
+
+func newFakeRateLimiter() *fakeRateLimiter {
+	return &fakeRateLimiter{counters: map[string]int{}}
+}
+
+func (f *fakeRateLimiter) RateLimit(_ context.Context, key string, limit int, _ time.Duration) (bool, int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.counters[key]++
+	count := f.counters[key]
+	if count > limit {
+		return false, 0, nil
+	}
+	return true, limit - count, nil
+}
 
 // TestBuildCreateRateLimiter_DisabledByDefault: with RateLimitRPS=0
 // the constructor returns no middleware -- the existing
@@ -22,7 +52,8 @@ import (
 func TestBuildCreateRateLimiter_DisabledByDefault(t *testing.T) {
 	t.Parallel()
 	cfg := config.Config{} // zero value, RateLimitRPS=0
-	if got := buildCreateRateLimiter(cfg, slog.New(slog.DiscardHandler)); got != nil {
+	// rl is nil intentionally: the function must return before touching it.
+	if got := buildCreateRateLimiter(cfg, nil, slog.New(slog.DiscardHandler)); got != nil {
 		t.Errorf("buildCreateRateLimiter(rps=0) = %d middleware, want nil", len(got))
 	}
 }
@@ -34,7 +65,7 @@ func TestBuildCreateRateLimiter_DisabledByDefault(t *testing.T) {
 func TestBuildCreateRateLimiter_DeniesAfterBurst(t *testing.T) {
 	t.Parallel()
 	cfg := config.Config{RateLimitRPS: 1, RateLimitBurst: 2}
-	mws := buildCreateRateLimiter(cfg, slog.New(slog.DiscardHandler))
+	mws := buildCreateRateLimiter(cfg, newFakeRateLimiter(), slog.New(slog.DiscardHandler))
 	if len(mws) != 1 {
 		t.Fatalf("buildCreateRateLimiter mws = %d, want 1", len(mws))
 	}
@@ -91,7 +122,7 @@ func TestBuildCreateRateLimiter_DeniesAfterBurst(t *testing.T) {
 func TestBuildCreateRateLimiter_PerIPIsolation(t *testing.T) {
 	t.Parallel()
 	cfg := config.Config{RateLimitRPS: 1, RateLimitBurst: 1}
-	mws := buildCreateRateLimiter(cfg, slog.New(slog.DiscardHandler))
+	mws := buildCreateRateLimiter(cfg, newFakeRateLimiter(), slog.New(slog.DiscardHandler))
 
 	e := echo.New()
 	e.POST("/x", func(c *echo.Context) error {
@@ -126,7 +157,7 @@ func TestBuildCreateRateLimiter_PerIPIsolation(t *testing.T) {
 func TestBuildCreateRateLimiter_BurstDerivedFromRPS(t *testing.T) {
 	t.Parallel()
 	cfg := config.Config{RateLimitRPS: 0.25, RateLimitBurst: 0}
-	mws := buildCreateRateLimiter(cfg, slog.New(slog.DiscardHandler))
+	mws := buildCreateRateLimiter(cfg, newFakeRateLimiter(), slog.New(slog.DiscardHandler))
 
 	e := echo.New()
 	e.POST("/x", func(c *echo.Context) error { return c.NoContent(http.StatusCreated) }, mws...)
@@ -138,4 +169,42 @@ func TestBuildCreateRateLimiter_BurstDerivedFromRPS(t *testing.T) {
 	if rec.Code != http.StatusCreated {
 		t.Errorf("first call status = %d, want 201 (burst floor of 1 must apply)", rec.Code)
 	}
+}
+
+// TestBuildCreateRateLimiter_FailOpen: when the rate-limiter backend
+// returns an error the middleware must allow the request through
+// (fail-open) so a Redis outage never turns into a service outage.
+func TestBuildCreateRateLimiter_FailOpen(t *testing.T) {
+	t.Parallel()
+
+	errRL := &errorRateLimiter{}
+	cfg := config.Config{RateLimitRPS: 1, RateLimitBurst: 1}
+	mws := buildCreateRateLimiter(cfg, errRL, slog.New(slog.DiscardHandler))
+
+	e := echo.New()
+	hits := 0
+	e.POST("/x", func(c *echo.Context) error {
+		hits++
+		return c.NoContent(http.StatusCreated)
+	}, mws...)
+
+	for i := range 3 {
+		req := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(""))
+		req.RemoteAddr = "203.0.113.1:1234"
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		if rec.Code != http.StatusCreated {
+			t.Errorf("request %d: status = %d, want 201 (fail-open)", i+1, rec.Code)
+		}
+	}
+	if hits != 3 {
+		t.Errorf("handler invocations = %d, want 3 (all must pass on backend error)", hits)
+	}
+}
+
+// errorRateLimiter always returns an error, simulating a Redis outage.
+type errorRateLimiter struct{}
+
+func (*errorRateLimiter) RateLimit(_ context.Context, _ string, _ int, _ time.Duration) (bool, int, error) {
+	return false, 0, errors.New("simulated redis error")
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -152,7 +152,7 @@ func New(cfg config.Config, logger *slog.Logger, deps Deps) *Server {
 		CacheTTL:         cfg.CacheTTL,
 		NegativeCacheTTL: cfg.NegativeCacheTTL,
 	})
-	createMW := buildCreateRateLimiter(cfg, logger)
+	createMW := buildCreateRateLimiter(cfg, deps.Cache, logger)
 	links.Mount(e, createMW...)
 
 	// SPA shell + static assets. The Vite + Svelte build emits


### PR DESCRIPTION
## Problem

The previous in-memory rate limiter (Echo's token bucket) was per-process. With N Kubernetes replicas a single IP could hit N × RPS before any pod returned 429.

## Solution

Replace the in-memory store with a **Redis fixed-window counter** shared across all replicas.

### `cache.Client.RateLimit` (new method)

```go
func (c *Client) RateLimit(ctx context.Context, key string, limit int, window time.Duration) (bool, int, error)
```

Atomic Lua script — `INCR` the per-IP key, set `PEXPIRE` on first use. No external library needed.

### `server.rateLimiter` (new interface)

```go
type rateLimiter interface {
    RateLimit(ctx context.Context, key string, limit int, window time.Duration) (bool, int, error)
}
```

Injected into `buildCreateRateLimiter` so tests run without Redis (fake) and production wires `*cache.Client` directly.

### Behaviour

| Scenario | Result |
|----------|--------|
| Within budget | 200/201 as normal |
| Over budget | 429 with `{"code":"rate_limited"}` |
| Redis error | **Fail-open** — request allowed, Warn logged |

Config knobs (`URL_SHORTENER_RATE_LIMIT_RPS`, `URL_SHORTENER_RATE_LIMIT_BURST`) are unchanged.

### Tests

- `fakeRateLimiter`: in-memory fixed-window fake; all existing unit tests updated
- `errorRateLimiter`: always errors; drives new `TestBuildCreateRateLimiter_FailOpen`
- `TestRateLimit_FixedWindowBehavior` (integration): allow → deny → reset after window
- `TestRateLimit_PerKeyIsolation` (integration): distinct keys are independent