### PR TITLE
feat(server): add Content-Security-Policy header

### DIFF
--- a/internal/handlers/openapi.go
+++ b/internal/handlers/openapi.go
@@ -67,27 +67,12 @@ var swaggerUIHTML = `<!doctype html>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>url-shortener API -- Swagger UI</title>
   <link rel="stylesheet" href="/static/swagger-ui.css">
-  <style>body { margin: 0; }</style>
 </head>
-<body>
+<body style="margin:0">
   <div id="swagger-ui"></div>
   <script src="/static/swagger-ui-bundle.js" crossorigin></script>
   <script src="/static/swagger-ui-standalone-preset.js" crossorigin></script>
-  <script>
-    window.addEventListener("load", function () {
-      window.ui = SwaggerUIBundle({
-        url: "./openapi.json",
-        dom_id: "#swagger-ui",
-        deepLinking: true,
-        tryItOutEnabled: true,
-        presets: [
-          SwaggerUIBundle.presets.apis,
-          SwaggerUIStandalonePreset
-        ],
-        layout: "StandaloneLayout"
-      });
-    });
-  </script>
+  <script src="/swagger-ui-init.js" crossorigin></script>
 </body>
 </html>
 `

--- a/internal/handlers/openapi_test.go
+++ b/internal/handlers/openapi_test.go
@@ -88,13 +88,13 @@ func TestMountOpenAPI(t *testing.T) {
 	// references the right asset) -- the bundles themselves are
 	// vendored npm artifacts and not the test's job to validate.
 	htmlCases := []struct {
-		name        string
-		path        string
-		wantTitle   string
-		wantAsset   string
-		wantSpecRef string
+		name      string
+		path      string
+		wantTitle string
+		wantAsset string
+		wantRef   string
 	}{
-		{"swagger-ui", "/api/v1/docs", "Swagger UI", "/static/swagger-ui-bundle.js", "./openapi.json"},
+		{"swagger-ui", "/api/v1/docs", "Swagger UI", "/static/swagger-ui-bundle.js", "/swagger-ui-init.js"},
 		{"redoc", "/api/v1/redoc", "Redoc", "/static/redoc.standalone.js", "./openapi.json"},
 	}
 	for _, tc := range htmlCases {
@@ -118,8 +118,8 @@ func TestMountOpenAPI(t *testing.T) {
 			if !strings.Contains(body, tc.wantAsset) {
 				t.Errorf("body does not reference vendored asset %q", tc.wantAsset)
 			}
-			if !strings.Contains(body, tc.wantSpecRef) {
-				t.Errorf("body does not reference spec at %q", tc.wantSpecRef)
+			if !strings.Contains(body, tc.wantRef) {
+				t.Errorf("body does not contain expected reference %q", tc.wantRef)
 			}
 		})
 	}

--- a/internal/server/secure.go
+++ b/internal/server/secure.go
@@ -12,9 +12,41 @@ import (
 // deployment uses TLS.
 const hstsMaxAge = 63072000 // 2 years
 
+// csp is the Content-Security-Policy directive set for all responses.
+//
+//   - default-src 'self'        — baseline; only same-origin resources.
+//   - script-src 'self'         — all scripts must be served from this
+//     origin; no inline scripts, so injected JS is blocked (XSS).
+//   - style-src 'self' 'unsafe-inline' — same-origin stylesheets; inline
+//     styles are permitted because Swagger UI and Redoc inject them via
+//     React at runtime and those cannot be hashed ahead of time.
+//   - img-src 'self' data:      — data URIs used for icons by Swagger UI.
+//   - font-src 'self' data:     — data URIs used for embedded fonts in
+//     vendored CSS bundles.
+//   - connect-src 'self'        — fetch/XHR must target this origin.
+//   - worker-src 'self' blob:   — Redoc spawns a blob: Web Worker for
+//     YAML parsing.
+//   - frame-ancestors 'none'    — prevents iframe embedding (clickjacking),
+//     complementing X-Frame-Options: SAMEORIGIN.
+//   - base-uri 'self'           — prevents <base> tag injection.
+//   - form-action 'self'        — form submissions stay on-origin.
+//   - object-src 'none'         — blocks Flash and other legacy plugins.
+const csp = "default-src 'self'; " +
+	"script-src 'self'; " +
+	"style-src 'self' 'unsafe-inline'; " +
+	"img-src 'self' data:; " +
+	"font-src 'self' data:; " +
+	"connect-src 'self'; " +
+	"worker-src 'self' blob:; " +
+	"frame-ancestors 'none'; " +
+	"base-uri 'self'; " +
+	"form-action 'self'; " +
+	"object-src 'none'"
+
 // buildSecureHeaders returns the Echo Secure middleware configured for
 // this service. The returned middleware always sets:
 //
+//   - Content-Security-Policy: (see [csp] constant above)
 //   - X-Content-Type-Options: nosniff
 //   - X-Frame-Options: SAMEORIGIN
 //   - X-XSS-Protection: 1; mode=block
@@ -25,10 +57,11 @@ const hstsMaxAge = 63072000 // 2 years
 //   - Strict-Transport-Security: max-age=63072000; includeSubDomains
 func buildSecureHeaders() echo.MiddlewareFunc {
 	return middleware.SecureWithConfig(middleware.SecureConfig{
-		XSSProtection:      "1; mode=block",
-		ContentTypeNosniff: "nosniff",
-		XFrameOptions:      "SAMEORIGIN",
-		HSTSMaxAge:         hstsMaxAge,
-		ReferrerPolicy:     "strict-origin-when-cross-origin",
+		XSSProtection:         "1; mode=block",
+		ContentTypeNosniff:    "nosniff",
+		XFrameOptions:         "SAMEORIGIN",
+		HSTSMaxAge:            hstsMaxAge,
+		ReferrerPolicy:        "strict-origin-when-cross-origin",
+		ContentSecurityPolicy: csp,
 	})
 }

--- a/internal/server/secure_test.go
+++ b/internal/server/secure_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/labstack/echo/v5"
@@ -86,5 +87,27 @@ func TestSecureHeaders_HSTSViaXForwardedProto(t *testing.T) {
 	wantPrefix := "max-age=63072000"
 	if len(hsts) < len(wantPrefix) || hsts[:len(wantPrefix)] != wantPrefix {
 		t.Errorf("Strict-Transport-Security = %q, want prefix %q", hsts, wantPrefix)
+	}
+}
+
+// TestSecureHeaders_CSP verifies that every response carries a
+// Content-Security-Policy header and that it contains the core
+// directives that guard against XSS and clickjacking.
+func TestSecureHeaders_CSP(t *testing.T) {
+	t.Parallel()
+	rec := doPlainRequest(t, newSecureEchoForTest(t))
+	got := rec.Header().Get("Content-Security-Policy")
+	if got == "" {
+		t.Fatal("Content-Security-Policy header missing")
+	}
+	for _, want := range []string{
+		"default-src 'self'",
+		"script-src 'self'",
+		"frame-ancestors 'none'",
+		"object-src 'none'",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Content-Security-Policy missing directive %q; got: %s", want, got)
+		}
 	}
 }

--- a/web/index.html
+++ b/web/index.html
@@ -14,24 +14,11 @@
     <!--
       Theme boot: applies the saved theme (or system preference if
       none) BEFORE the stylesheet is parsed so the page never paints
-      with the wrong colours. Must stay inline + synchronous; the
-      toggle UI is wired up later by the Svelte ThemeToggle component.
+      with the wrong colours. Synchronous (no defer/async) so it runs
+      before first paint; the toggle UI is wired up later by the Svelte
+      ThemeToggle component.
     -->
-    <script>
-      (function () {
-        try {
-          var t = localStorage.getItem("theme");
-          var dark =
-            t === "dark" ||
-            (t !== "light" &&
-              window.matchMedia &&
-              window.matchMedia("(prefers-color-scheme: dark)").matches);
-          if (dark) document.documentElement.classList.add("dark");
-        } catch (_) {
-          // localStorage may throw in private mode -- fall back to light.
-        }
-      })();
-    </script>
+    <script src="/theme-init.js"></script>
   </head>
   <body
     class="min-h-full flex flex-col bg-slate-50 text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-100 selection:bg-indigo-200 dark:selection:bg-indigo-500/40"

--- a/web/public/swagger-ui-init.js
+++ b/web/public/swagger-ui-init.js
@@ -1,0 +1,16 @@
+// Swagger UI initialisation. Referenced as a plain <script src="...">
+// from the /api/v1/docs page so that Content-Security-Policy can use
+// script-src 'self' without requiring 'unsafe-inline'.
+window.addEventListener("load", function () {
+  window.ui = SwaggerUIBundle({
+    url: "./openapi.json",
+    dom_id: "#swagger-ui",
+    deepLinking: true,
+    tryItOutEnabled: true,
+    presets: [
+      SwaggerUIBundle.presets.apis,
+      SwaggerUIStandalonePreset,
+    ],
+    layout: "StandaloneLayout",
+  });
+});

--- a/web/public/theme-init.js
+++ b/web/public/theme-init.js
@@ -1,0 +1,18 @@
+// Theme boot: applies the saved theme (or system preference if none)
+// BEFORE the stylesheet is parsed so the page never paints with the
+// wrong colours. Referenced as a synchronous (no defer/async) script
+// from index.html so it runs before first paint. Must stay a plain
+// script to avoid requiring 'unsafe-inline' in Content-Security-Policy.
+(function () {
+  try {
+    var t = localStorage.getItem("theme");
+    var dark =
+      t === "dark" ||
+      (t !== "light" &&
+        window.matchMedia &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches);
+    if (dark) document.documentElement.classList.add("dark");
+  } catch (_) {
+    // localStorage may throw in private mode -- fall back to light.
+  }
+})();


### PR DESCRIPTION
## Summary

Add a `Content-Security-Policy` header to every HTTP response to protect against XSS and related injection attacks.

## Directives

| Directive | Value | Rationale |
|---|---|---|
| `script-src` | `'self'` | All scripts must come from this origin. No `unsafe-inline` — inline scripts have been extracted (see below). |
| `style-src` | `'self' 'unsafe-inline'` | Swagger UI and Redoc inject inline styles via React at runtime; cannot eliminate `unsafe-inline` here. |
| `img-src` / `font-src` | `'self' data:` | Vendored UI bundles use `data:` URIs for icons and embedded fonts. |
| `connect-src` | `'self'` | `fetch`/XHR calls stay on-origin. |
| `worker-src` | `'self' blob:` | Redoc spawns a `blob:` Web Worker for YAML parsing. |
| `frame-ancestors` | `'none'` | Clickjacking protection, complementing `X-Frame-Options: SAMEORIGIN`. |
| `base-uri` / `form-action` | `'self'` | Prevent `<base>` tag injection and off-origin form submissions. |
| `object-src` | `'none'` | Block legacy plugins (Flash, etc.). |

## Inline script extraction

To achieve `script-src 'self'` without `unsafe-inline`, the two existing inline scripts are moved to external files that Vite copies into `web/dist/` and the binary embeds:

- **`web/public/theme-init.js`** — theme-boot IIFE (previously inline in `web/index.html`)
- **`web/public/swagger-ui-init.js`** — Swagger UI initialiser (previously inline in the `/api/v1/docs` HTML template in `internal/handlers/openapi.go`)

## Testing

- `TestSecureHeaders_CSP` added to `internal/server/secure_test.go` — asserts the header is present and contains the key directives (`default-src`, `script-src`, `frame-ancestors`, `object-src`).
- `TestMountOpenAPI/swagger-ui` assertion updated to check for `/swagger-ui-init.js` reference instead of the now-removed inline spec URL.
