### PR TITLE
feat(web): show version string in footer

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -114,6 +114,33 @@ run *ARGS:
 version:
     @go run ./cmd/url-shortener version 2>/dev/null || echo "Version (resolved): {{ VERSION }}"
 
+# Bring up the dev stack (db + redis + server) with build metadata injected
+# from the current git state, so /version reports the real revision.
+# Extra flags are forwarded: e.g. `just up -d --build --wait`.
+[group("dev")]
+up *ARGS:
+    VERSION="{{ VERSION }}" COMMIT="{{ COMMIT }}" DATE="{{ DATE }}" docker compose --profile=dev up {{ ARGS }}
+
+# Bring up the TLS stack (db + redis + server-tls on :8443) with build
+# metadata injected from the current git state. Requires certs in
+# dev/certs/ -- run `just dev-certs` once to generate them.
+# Extra flags are forwarded: e.g. `just up-tls -d --build --wait`.
+[group("dev")]
+up-tls *ARGS:
+    VERSION="{{ VERSION }}" COMMIT="{{ COMMIT }}" DATE="{{ DATE }}" docker compose --profile=tls up {{ ARGS }}
+
+# Tear down the dev stack and remove volumes.
+# Extra flags are forwarded: e.g. `just down -v`.
+[group("dev")]
+down *ARGS:
+    docker compose --profile=dev down {{ ARGS }}
+
+# Tear down the TLS stack and remove volumes.
+# Extra flags are forwarded: e.g. `just down-tls -v`.
+[group("dev")]
+down-tls *ARGS:
+    docker compose --profile=tls down {{ ARGS }}
+
 # Generate a host-trusted dev TLS cert + key into dev/certs/ via mkcert.
 # Both files are gitignored; every contributor regenerates locally.
 #

--- a/compose.yaml
+++ b/compose.yaml
@@ -119,8 +119,8 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        VERSION: dev
-        COMMIT: dev
+        VERSION: ${VERSION:-v0.0.0-dev}
+        COMMIT: ${COMMIT:-unknown}
     command: ["run"]
     depends_on:
       db:
@@ -167,8 +167,8 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        VERSION: dev
-        COMMIT: dev
+        VERSION: ${VERSION:-v0.0.0-dev}
+        COMMIT: ${COMMIT:-unknown}
     command: ["run"]
     depends_on:
       db:

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { listLinks, type Link } from "./lib/api";
+  import { listLinks, getVersion, type Link } from "./lib/api";
   import LinkForm from "./lib/LinkForm.svelte";
   import LinkResult from "./lib/LinkResult.svelte";
   import LinkError from "./lib/LinkError.svelte";
@@ -9,6 +9,7 @@
 
   let items: Link[] = $state([]);
   let nextCursor: number | null = $state(null);
+  let version: string | null = $state(null);
 
   let result: { link: Link; created: boolean } | null = $state(null);
   let error: { message: string } | null = $state(null);
@@ -28,7 +29,15 @@
     }
   }
 
-  onMount(refreshFirstPage);
+  onMount(async () => {
+    await refreshFirstPage();
+    try {
+      const info = await getVersion();
+      version = info.version;
+    } catch {
+      // Version fetch is best-effort; don't surface failures to the user.
+    }
+  });
 
   async function onCreated(payload: { link: Link; created: boolean }): Promise<void> {
     result = payload;
@@ -152,6 +161,10 @@
           >Tailwind CSS</a
         >
       </li>
+      {#if version}
+        <li aria-hidden="true" class="text-slate-300 dark:text-slate-600 select-none">&middot;</li>
+        <li><span class="font-mono">{version}</span></li>
+      {/if}
     </ul>
   </div>
 </footer>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -104,6 +104,18 @@ export async function listLinks(params: ListLinksParams = {}): Promise<ListLinks
   return (await resp.json()) as ListLinksResponse;
 }
 
+export interface VersionInfo {
+  version: string;
+  commit: string;
+  date: string;
+}
+
+export async function getVersion(): Promise<VersionInfo> {
+  const resp = await fetch("/version");
+  if (!resp.ok) throw await asApiError(resp);
+  return (await resp.json()) as VersionInfo;
+}
+
 /**
  * Type-guard for `ApiError` values. Useful in catch blocks where
  * `unknown` is the inferred error type under TypeScript strict mode.


### PR DESCRIPTION
## Summary

Three related improvements that together make the running binary's version visible in the web UI and easier to inject at compose build time.

### Web UI — version string in footer

`GET /version` is called once on mount. The version string is appended to the right-hand tech-stack list in the footer as a monospaced tag (e.g. `v1.2.3`, `v0.0.0-dev`). The fetch is best-effort: errors are silently swallowed so a slow or unavailable server never prevents the UI from rendering.

### `compose.yaml` — proper build-arg injection

The hardcoded `VERSION: dev` / `COMMIT: dev` build args are replaced with env-var substitution:

```yaml
args:
  VERSION: ${VERSION:-v0.0.0-dev}
  COMMIT: ${COMMIT:-unknown}
```

Docker Compose reads `VERSION` and `COMMIT` from the calling shell, falling back to the defaults when unset. Applied to both `server` (`dev` profile) and `server-tls` (`tls` profile).

### `Justfile` — stack management recipes

Four new recipes so the compose stacks can be driven entirely through `just`:

| Recipe | Effect |
|---|---|
| `just up [FLAGS]` | Start dev stack with git-resolved `VERSION`/`COMMIT`/`DATE` |
| `just down [FLAGS]` | Tear down dev stack (pass `-v` to also remove volumes) |
| `just up-tls [FLAGS]` | Start TLS stack with git-resolved metadata |
| `just down-tls [FLAGS]` | Tear down TLS stack |

The `up` / `up-tls` recipes pre-populate the env vars that `compose.yaml` now reads, so `just up -d --build --wait` produces a binary whose `/version` endpoint reports the real git revision.
