### PR TITLE
chore: apply go fix modernizations and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ just test-integration                  # bring up test-profile infra, migrate, r
 just lint                              # run golangci-lint (auto-installs the pinned version)
 just govulncheck                       # run govulncheck against the latest Go vuln database
 just trivy-image                              # build the Docker image and scan it with Trivy (HIGH/CRITICAL)
-docker compose --profile=dev up --wait -d     # bring up the full local dev stack (db + redis + server on 5432/6379/8080)
+just up -d --build --wait                     # bring up the full local dev stack (db + redis + server on 5432/6379/8080), git metadata injected
 just compose-smoke                            # smoke-check a running stack: operational endpoints + shorten/redirect cycle
-docker compose --profile=dev down -v          # tear down the dev stack
+just down -v                                  # tear down the dev stack
 docker compose --profile=test down -v         # tear down the test-profile stack (db-test + redis-test on 5433/6380)
 ```
 
@@ -144,8 +144,8 @@ local `compose.yaml` overrides them for development.
 | `URL_SHORTENER_TLS_CERT_FILE`  | _(empty)_                     | Path to a PEM-encoded server certificate. When set together with `URL_SHORTENER_TLS_KEY_FILE`, the server speaks HTTPS on `URL_SHORTENER_ADDR`; otherwise it stays on plain HTTP (the right choice when fronted by a TLS-terminating reverse proxy). Both must be set together -- one without the other is a startup error. See [Deployment](#deployment). |
 | `URL_SHORTENER_TLS_KEY_FILE`   | _(empty)_                     | Path to the PEM-encoded private key matching `URL_SHORTENER_TLS_CERT_FILE`. |
 | `URL_SHORTENER_TRUSTED_PROXIES` | _(empty)_                    | Comma-separated CIDR list (e.g. `127.0.0.1/32,10.0.0.0/8`). When a request's `RemoteAddr` falls inside one of these ranges the server walks `X-Forwarded-For` to find the original client IP; otherwise XFF is ignored. Empty leaves no proxy trust configured -- safe default for direct-to-internet deployments. See [Reverse-proxy deployment (Caddy)](#reverse-proxy-deployment-caddy). |
-| `URL_SHORTENER_RATE_LIMIT_RPS` | `0`                           | When `> 0`, enables an in-memory per-IP rate limiter on `POST /api/v1/links` at the given steady-state requests-per-second budget. `0` (the default) disables rate limiting; deployments fronted by an upstream limiter typically leave this off. Per-IP keying uses `URL_SHORTENER_TRUSTED_PROXIES` for XFF resolution. |
-| `URL_SHORTENER_RATE_LIMIT_BURST` | _(2 &times; RPS, min 1)_    | Token-bucket capacity for the rate limiter. `0` means "derive from `URL_SHORTENER_RATE_LIMIT_RPS`". Ignored when `RATE_LIMIT_RPS=0`. |
+| `URL_SHORTENER_RATE_LIMIT_RPS` | `0`                           | When `> 0`, enables a **Redis-backed fixed-window per-IP rate limiter** on `POST /api/v1/links` at the given requests-per-second budget. `0` (the default) disables rate limiting. Enforced consistently across all replicas because the counter lives in Redis. Per-IP keying uses `URL_SHORTENER_TRUSTED_PROXIES` for XFF resolution. Fails open: a Redis error lets the request through and logs a warning. |
+| `URL_SHORTENER_RATE_LIMIT_BURST` | _(2 &times; RPS, min 1)_    | Window capacity for the rate limiter (`burst` requests per 1-second window). `0` means "derive from `URL_SHORTENER_RATE_LIMIT_RPS`". Ignored when `RATE_LIMIT_RPS=0`. |
 | `URL_SHORTENER_CORS_ALLOWED_ORIGINS` | _(empty)_               | Comma-separated allow-list of cross-origin browser callers (e.g. `https://app.example.com,https://status.example.com`). Each entry must be `*` or an absolute `scheme://host[:port]` URL -- typos like `example.com` (no scheme) are rejected at startup. Empty (the default) leaves CORS off, which is correct for the same-origin SPA + API deployment this project ships. |
 | `URL_SHORTENER_CACHE_TTL`            | `1h`                    | How long a positive redirect lookup is cached in Redis. Accepts Go duration syntax (e.g. `30m`, `2h`). `0` uses the default. |
 | `URL_SHORTENER_NEGATIVE_CACHE_TTL`   | `30s`                   | How long a "not found / gone" answer for `/r/:code` is held in Redis before re-checking Postgres. Short on purpose: absorbs scanning attacks without masking legitimate state changes. Accepts Go duration syntax. `0` uses the default. |
@@ -165,11 +165,18 @@ whether TLS is in use:
 
 | Header | Value |
 | ------ | ----- |
+| `Content-Security-Policy` | `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'` |
 | `X-Content-Type-Options` | `nosniff` |
 | `X-Frame-Options` | `SAMEORIGIN` |
 | `X-XSS-Protection` | `1; mode=block` |
 | `Referrer-Policy` | `strict-origin-when-cross-origin` |
 | `Strict-Transport-Security` | `max-age=63072000; includeSubDomains` (HTTPS requests only) |
+
+`script-src 'self'` is kept strict (no `unsafe-inline`) because the two
+inline scripts that shipped in the original HTML have been extracted to
+external files (`/theme-init.js`, `/swagger-ui-init.js`) served from the
+same origin. `style-src` allows `unsafe-inline` because Swagger UI and
+Redoc inject inline styles via React at runtime.
 
 HSTS is only emitted when the request arrives over TLS (direct or via a
 proxy that sets `X-Forwarded-Proto: https`), so plain-HTTP deployments
@@ -297,6 +304,8 @@ already present elsewhere -- two codes can legitimately point at the same
 destination. Dedup is best-effort under concurrent writes (no unique
 constraint on `target_url`).
 
+Dedup is **atomic**: the store uses a single `INSERT … ON CONFLICT (target_url) … DO UPDATE … RETURNING` round-trip backed by a partial unique index on `(target_url) WHERE auto_dedup = true AND expires_at IS NULL AND deleted_at IS NULL`. Concurrent replicas that receive the same target URL simultaneously will both attempt the upsert; exactly one wins the insert and the other receives the existing row. No separate SELECT is needed and no TOCTOU window exists.
+
 Dedup is also suppressed whenever expiry is involved on either side: a
 request carrying `expires_at` always mints a fresh code (so an
 ephemeral request never silently extends a permanent row's lifetime),
@@ -385,9 +394,9 @@ distroless container and exposes the app on `:8443`:
 
 ```sh
 just dev-certs                                  # one-time per host
-docker compose --profile=tls up --wait -d
+just up-tls -d --build --wait
 curl https://localhost:8443/healthz             # {"status":"ok"}
-docker compose --profile=tls down -v
+just down-tls -v
 ```
 
 The `tls` profile shares the `db` and `redis` services with `dev` (it

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -358,15 +358,15 @@ func TestValidate_TLSAndTrustedProxies(t *testing.T) {
 func clearEnv(t *testing.T) {
 	t.Helper()
 	for _, kv := range os.Environ() {
-		i := strings.IndexByte(kv, '=')
-		if i < 0 {
+		before, after, ok := strings.Cut(kv, "=")
+		if !ok {
 			continue
 		}
-		k := kv[:i]
+		k := before
 		if !strings.HasPrefix(k, config.EnvPrefix+"_") {
 			continue
 		}
-		orig := kv[i+1:]
+		orig := after
 		if err := os.Unsetenv(k); err != nil {
 			t.Fatalf("Unsetenv(%q): %v", k, err)
 		}

--- a/internal/handlers/links_cache.go
+++ b/internal/handlers/links_cache.go
@@ -84,15 +84,13 @@ func cacheKey(code string) string { return "link:" + code }
 // inside the goroutine; non-transient errors and exhausted budgets
 // are logged and dropped, since the click counter is best-effort.
 func (h *Links) recordClick(code string) {
-	h.bgWG.Add(1)
-	go func() {
-		defer h.bgWG.Done()
+	h.bgWG.Go(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), clickTimeout)
 		defer cancel()
 		if err := h.incrementClicksWithRetry(ctx, code); err != nil {
 			h.logger.Warn("links: increment clicks failed", "error", err, "code", code)
 		}
-	}()
+	})
 }
 
 // incrementClicksWithRetry calls store.IncrementClicks with bounded

--- a/internal/handlers/links_service.go
+++ b/internal/handlers/links_service.go
@@ -147,7 +147,7 @@ func (h *Links) listPage(ctx context.Context, pageSize int, beforeID int64) ([]s
 // Returns (link, true, nil) when a fresh row is inserted and
 // (link, false, nil) when an existing permanent row is reused.
 func (h *Links) createOrReuseAutoLink(ctx context.Context, target string) (store.Link, bool, error) {
-	for i := 0; i < CreateMaxRetries; i++ {
+	for i := range CreateMaxRetries {
 		code, err := h.gen.Generate()
 		if err != nil {
 			return store.Link{}, false, fmt.Errorf("generate code: %w", err)
@@ -170,7 +170,7 @@ func (h *Links) createOrReuseAutoLink(ctx context.Context, target string) (store
 // implies either an exhausted keyspace or a degenerate generator and
 // should surface as a 500.
 func (h *Links) createWithRandomCode(ctx context.Context, target string, expiresAt *time.Time) (store.Link, error) {
-	for i := 0; i < CreateMaxRetries; i++ {
+	for i := range CreateMaxRetries {
 		code, err := h.gen.Generate()
 		if err != nil {
 			return store.Link{}, fmt.Errorf("generate code: %w", err)

--- a/internal/handlers/links_test.go
+++ b/internal/handlers/links_test.go
@@ -980,7 +980,7 @@ func TestRedirect_IncrementsClickCount(t *testing.T) {
 	}
 	e, h := newHandlerWithCache(t, st, cc, &scriptedGen{})
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		req := httptest.NewRequest(http.MethodGet, "/r/tracked", nil)
 		rec := httptest.NewRecorder()
 		e.ServeHTTP(rec, req)
@@ -1308,7 +1308,7 @@ func TestList_DefaultsTo10NewestFirstWithCursorWhenMore(t *testing.T) {
 	t.Parallel()
 	st, cc := newFakeStore(), newFakeCache()
 	// Seed 12 links so the default page-size of 10 returns 10 + a cursor.
-	for i := 0; i < 12; i++ {
+	for i := range 12 {
 		code := fmt.Sprintf("code%03d", i)
 		if _, err := st.CreateLink(context.Background(), nil, code, fmt.Sprintf("https://example.com/%d", i), nil); err != nil {
 			t.Fatalf("seed: %v", err)
@@ -1336,7 +1336,7 @@ func TestList_DefaultsTo10NewestFirstWithCursorWhenMore(t *testing.T) {
 func TestList_BeforeCursorWalksOlderRows(t *testing.T) {
 	t.Parallel()
 	st, cc := newFakeStore(), newFakeCache()
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		code := fmt.Sprintf("walk%03d", i)
 		if _, err := st.CreateLink(context.Background(), nil, code, fmt.Sprintf("https://example.com/%d", i), nil); err != nil {
 			t.Fatalf("seed: %v", err)
@@ -1371,7 +1371,7 @@ func TestList_BeforeCursorWalksOlderRows(t *testing.T) {
 func TestList_LimitClampedToMax(t *testing.T) {
 	t.Parallel()
 	st, cc := newFakeStore(), newFakeCache()
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		code := fmt.Sprintf("clamp%02d", i)
 		if _, err := st.CreateLink(context.Background(), nil, code, fmt.Sprintf("https://example.com/%d", i), nil); err != nil {
 			t.Fatalf("seed: %v", err)
@@ -1394,7 +1394,7 @@ func TestList_LimitClampedToMax(t *testing.T) {
 func TestList_BadLimitFallsBackToDefault(t *testing.T) {
 	t.Parallel()
 	st, cc := newFakeStore(), newFakeCache()
-	for i := 0; i < 11; i++ {
+	for i := range 11 {
 		code := fmt.Sprintf("bad%04d", i)
 		if _, err := st.CreateLink(context.Background(), nil, code, fmt.Sprintf("https://example.com/%d", i), nil); err != nil {
 			t.Fatalf("seed: %v", err)

--- a/internal/server/ratelimit.go
+++ b/internal/server/ratelimit.go
@@ -52,10 +52,7 @@ func buildCreateRateLimiter(cfg config.Config, rl rateLimiter, logger *slog.Logg
 		// "create" a couple of times in a row stays inside the
 		// budget. Floor at 1 so a fractional RPS like 0.5 still
 		// admits at least one request.
-		burst = int(cfg.RateLimitRPS * 2)
-		if burst < 1 {
-			burst = 1
-		}
+		burst = max(int(cfg.RateLimitRPS*2), 1)
 	}
 
 	// Fixed window of 1 second: `burst` requests per second per IP.

--- a/internal/shortener/shortener_test.go
+++ b/internal/shortener/shortener_test.go
@@ -36,7 +36,7 @@ func TestGenerate_ProducesCodesOfTheRequestedLengthAndAlphabet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewGenerator: %v", err)
 	}
-	for i := 0; i < 256; i++ {
+	for range 256 {
 		code, err := g.Generate()
 		if err != nil {
 			t.Fatalf("Generate: %v", err)
@@ -62,7 +62,7 @@ func TestGenerate_ProducesDistinctCodesAcrossManyDraws(t *testing.T) {
 	}
 	const draws = 1024
 	seen := make(map[string]struct{}, draws)
-	for i := 0; i < draws; i++ {
+	for i := range draws {
 		code, err := g.Generate()
 		if err != nil {
 			t.Fatalf("Generate: %v", err)


### PR DESCRIPTION
## Summary

Two separate concerns in one PR: automated `go fix` rewrites and README catch-up.

### `go fix` modernizations

Run `go fix ./...` against Go 1.26.3, which applied the following rewrites:

| Old pattern | New pattern | Since |
|---|---|---|
| `strings.IndexByte` + manual slice split | `strings.Cut` | Go 1.18 |
| `wg.Add(1)` / goroutine / `defer wg.Done()` | `wg.Go(func() { … })` | Go 1.25 |
| `for i := 0; i < N; i++` (unused `i`) | `for range N` | Go 1.22 |
| `for i := 0; i < N; i++` (used `i`) | `for i := range N` | Go 1.22 |
| `if x < 1 { x = 1 }` | `max(x, 1)` | Go 1.21 |

All tests pass (`go test -race ./...`) with no other changes.

### README updates

Bringing the docs in line with recent merged work:

- **Workflow cheatsheet**: replaced bare `docker compose --profile=dev up/down` commands with `just up` / `just down` / `just up-tls` / `just down-tls` (added in the previous PR).
- **Security headers**: added the `Content-Security-Policy` row (merged in #105) with a short note on why `script-src` has no `unsafe-inline`.
- **Rate limiter config**: updated description from "in-memory" to **Redis-backed fixed-window** (merged in #104).
- **Deduplication**: documented the **atomic `ON CONFLICT` upsert** (merged in #103) that replaced the old racy SELECT + INSERT pattern.
- **TLS compose example**: updated to use `just up-tls` / `just down-tls`.
