### PR TITLE
refactor(migrate): switch to goose Provider API with advisory lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ local `compose.yaml` overrides them for development.
 | `URL_SHORTENER_LOG_FORMAT`     | `text` in dev, `json` in prod | `text` (human-readable) or `json` (structured).     |
 | `URL_SHORTENER_DATABASE_URL`   | _(empty)_                     | **Required.** Postgres connection string. Redacted when printed. |
 | `URL_SHORTENER_REDIS_URL`      | _(empty)_                     | **Required.** Redis connection string. Redacted when printed.   |
-| `URL_SHORTENER_AUTO_MIGRATE`   | `false`                       | When `true`, `run` applies migrations before serving. Convenient for local dev / single-replica CI; production deployments should leave this off and run `migrate up` as a separate step. |
+| `URL_SHORTENER_AUTO_MIGRATE`   | `true`                        | When `true` (the default), `run` applies any pending migrations before serving. A Postgres advisory lock serializes concurrent startup across replicas. Set to `false` to run `migrate up` as an explicit, separately-audited step. |
 | `URL_SHORTENER_CODE_LENGTH`    | `7`                           | Length of auto-generated short codes (base62). Must be in [4, 64]. |
 | `URL_SHORTENER_DB_MAX_CONNS`           | _(pgx default: max(4, NumCPU))_ | Upper bound on simultaneous Postgres connections. Set above the default to absorb burst load without queueing requests on the pool. |
 | `URL_SHORTENER_DB_MIN_CONNS`           | _(pgx default: 0)_              | Idle connections kept warm. Useful to amortize TLS/handshake cost on bursty workloads. |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,11 +51,13 @@ type Config struct {
 	// Redacted() and by the JSON marshaller.
 	RedisURL string `mapstructure:"redis_url"    json:"redis_url"`
 
-	// AutoMigrate, when true, makes `run` apply pending migrations before
-	// starting the HTTP server. Convenient for local dev and CI where there
-	// is exactly one process; production deployments should keep this false
-	// and run `migrate up` as a separate one-shot step (avoids races between
-	// replicas).
+	// AutoMigrate, when true (the default), makes `run` apply any pending
+	// migrations before starting the HTTP server. The migration path uses a
+	// Postgres session-level advisory lock, so multiple replicas starting
+	// simultaneously are safe: the first to acquire the lock applies all
+	// pending migrations; the others wait, then see no pending work and
+	// continue. Set to false when you prefer to run `migrate up` as an
+	// explicit, separately-audited step outside the application process.
 	AutoMigrate bool `mapstructure:"auto_migrate" json:"auto_migrate"`
 
 	// CodeLength is the length of auto-generated short codes. Validated by
@@ -157,6 +159,7 @@ func Load() (Config, error) {
 	v.SetDefault("addr", ":8080")
 	v.SetDefault("base_url", "http://localhost:8080")
 	v.SetDefault("log_level", "info")
+	v.SetDefault("auto_migrate", true)
 	v.SetDefault("code_length", 7)
 	// log_format default is decided after env is known (text in dev, json in prod).
 

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -4,76 +4,92 @@ package migrate
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
-	"io/fs"
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/pressly/goose/v3"
+	"github.com/pressly/goose/v3/lock"
 
 	"github.com/vancanhuit/url-shortener/migrations"
 )
 
-// dialect is the goose dialect name for Postgres.
-const dialect = "postgres"
-
-// migrationsDir is the virtual directory inside the embedded FS. Goose uses
-// this to namespace its file lookups; "." means "the FS root".
-const migrationsDir = "."
-
-// Up applies all pending migrations.
+// Up applies all pending migrations. A Postgres session-level advisory lock
+// is acquired before any migration runs, so concurrent AutoMigrate calls from
+// multiple replicas starting simultaneously are serialized at the DB level.
 func Up(ctx context.Context, databaseURL string) error {
-	return run(ctx, databaseURL, func(db *sql.DB) error {
-		return goose.UpContext(ctx, db, migrationsDir)
+	return withProvider(ctx, databaseURL, func(p *goose.Provider) error {
+		results, err := p.Up(ctx)
+		for _, r := range results {
+			fmt.Println(r)
+		}
+		return err
 	})
 }
 
 // Down rolls back the most recent migration.
 func Down(ctx context.Context, databaseURL string) error {
-	return run(ctx, databaseURL, func(db *sql.DB) error {
-		return goose.DownContext(ctx, db, migrationsDir)
-	})
-}
-
-// Status prints the migration status (one line per migration) via goose's
-// default logger, which writes to stderr.
-func Status(ctx context.Context, databaseURL string) error {
-	return run(ctx, databaseURL, func(db *sql.DB) error {
-		return goose.StatusContext(ctx, db, migrationsDir)
-	})
-}
-
-// Versions returns the current goose_db_version in the target database and
-// the latest embedded migration version.
-func Versions(ctx context.Context, databaseURL string) (current int64, latest int64, err error) {
-	latest, err = latestEmbeddedVersion()
-	if err != nil {
-		return 0, 0, err
-	}
-
-	err = run(ctx, databaseURL, func(db *sql.DB) error {
-		v, e := goose.EnsureDBVersionContext(ctx, db)
-		if e != nil {
-			return e
+	return withProvider(ctx, databaseURL, func(p *goose.Provider) error {
+		result, err := p.Down(ctx)
+		if result != nil {
+			fmt.Println(result)
 		}
-		current = v
+		return err
+	})
+}
+
+// Status prints the migration status (one line per migration) to stdout.
+func Status(ctx context.Context, databaseURL string) error {
+	return withProvider(ctx, databaseURL, func(p *goose.Provider) error {
+		statuses, err := p.Status(ctx)
+		if err != nil {
+			return err
+		}
+		for _, s := range statuses {
+			state := "pending"
+			if s.State == goose.StateApplied {
+				state = "applied"
+			}
+			if s.AppliedAt.IsZero() {
+				fmt.Printf("%-7s -- v%05d %s\n", state, s.Source.Version, s.Source.Path)
+			} else {
+				fmt.Printf("%-7s %s v%05d %s\n", state, s.AppliedAt.UTC().Format("2006-01-02 15:04:05"), s.Source.Version, s.Source.Path)
+			}
+		}
 		return nil
 	})
-	if err != nil {
-		return 0, 0, err
-	}
-	return current, latest, nil
+}
+
+// Versions returns the current applied version and the latest embedded
+// migration version.
+func Versions(ctx context.Context, databaseURL string) (current int64, latest int64, err error) {
+	err = withProvider(ctx, databaseURL, func(p *goose.Provider) error {
+		var e error
+		current, latest, e = p.GetVersions(ctx)
+		return e
+	})
+	return current, latest, err
 }
 
 // Redo rolls back the most recently applied migration and immediately
-// re-applies it. This is useful during development to iterate on the
-// current migration without manually running down then up.
+// re-applies it. Useful during development to iterate on the current
+// migration without manually running down then up.
 func Redo(ctx context.Context, databaseURL string) error {
-	return run(ctx, databaseURL, func(db *sql.DB) error {
-		return goose.RedoContext(ctx, db, migrationsDir)
+	return withProvider(ctx, databaseURL, func(p *goose.Provider) error {
+		result, err := p.Down(ctx)
+		if err != nil {
+			return err
+		}
+		if result != nil {
+			fmt.Println(result)
+		}
+		results, err := p.Up(ctx)
+		for _, r := range results {
+			fmt.Println(r)
+		}
+		return err
 	})
 }
 
@@ -94,34 +110,10 @@ func Create(dir, name, migrationType string) error {
 	return goose.Create(nil, dir, name, migrationType)
 }
 
-func latestEmbeddedVersion() (int64, error) {
-	entries, err := fs.ReadDir(migrations.FS, migrationsDir)
-	if err != nil {
-		return 0, fmt.Errorf("migrate: read embedded migrations: %w", err)
-	}
-
-	var latest int64
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".sql") {
-			continue
-		}
-		version, err := goose.NumericComponent(e.Name())
-		if err != nil {
-			return 0, fmt.Errorf("migrate: parse migration version %q: %w", e.Name(), err)
-		}
-		if version > latest {
-			latest = version
-		}
-	}
-	if latest == 0 {
-		return 0, goose.ErrNoMigrationFiles
-	}
-	return latest, nil
-}
-
-// run opens a pgx pool, adapts it to *sql.DB for goose, configures goose with
-// the embedded FS + dialect, and runs op. It always closes the pool.
-func run(ctx context.Context, databaseURL string, op func(*sql.DB) error) error {
+// withProvider opens a pgx pool, adapts it to *sql.DB for goose, builds a
+// Provider with the embedded migrations FS and a Postgres advisory session
+// locker, calls op, then closes everything.
+func withProvider(ctx context.Context, databaseURL string, op func(*goose.Provider) error) error {
 	if databaseURL == "" {
 		return errors.New("migrate: database url is empty")
 	}
@@ -135,13 +127,22 @@ func run(ctx context.Context, databaseURL string, op func(*sql.DB) error) error 
 	db := stdlib.OpenDBFromPool(pool)
 	defer func() { _ = db.Close() }()
 
-	if err := goose.SetDialect(dialect); err != nil {
-		return fmt.Errorf("migrate: set dialect: %w", err)
+	locker, err := lock.NewPostgresSessionLocker()
+	if err != nil {
+		return fmt.Errorf("migrate: create session locker: %w", err)
 	}
-	goose.SetBaseFS(migrations.FS)
 
-	if err := op(db); err != nil {
-		return err
+	p, err := goose.NewProvider(
+		goose.DialectPostgres,
+		db,
+		migrations.FS,
+		goose.WithSessionLocker(locker),
+		goose.WithDisableGlobalRegistry(true),
+	)
+	if err != nil {
+		return fmt.Errorf("migrate: create provider: %w", err)
 	}
-	return nil
+	defer func() { _ = p.Close() }()
+
+	return op(p)
 }

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -1,21 +1,36 @@
 package migrate
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/vancanhuit/url-shortener/migrations"
 )
 
-func TestLatestEmbeddedVersion(t *testing.T) {
+// TestEmbeddedMigrationsFS verifies that the embedded migrations FS is
+// readable and contains the expected number of SQL files. This catches
+// accidental deletion or embed-directive omissions without needing a DB.
+func TestEmbeddedMigrationsFS(t *testing.T) {
 	t.Parallel()
 
-	got, err := latestEmbeddedVersion()
+	entries, err := fs.ReadDir(migrations.FS, ".")
 	if err != nil {
-		t.Fatalf("latestEmbeddedVersion() error = %v", err)
+		t.Fatalf("fs.ReadDir: %v", err)
 	}
-	if got != 5 {
-		t.Fatalf("latestEmbeddedVersion() = %d, want 5", got)
+
+	var sqlFiles []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".sql") {
+			sqlFiles = append(sqlFiles, e.Name())
+		}
+	}
+	const wantCount = 5
+	if len(sqlFiles) != wantCount {
+		t.Fatalf("embedded SQL migration count = %d, want %d (files: %v)",
+			len(sqlFiles), wantCount, sqlFiles)
 	}
 }
 


### PR DESCRIPTION
Switch from the legacy global goose API to the newer `Provider` API introduced in goose v3.

## Changes

### `internal/migrate/migrate.go`

- `withProvider()` helper builds a `*goose.Provider` per call using the embedded migrations FS and `lock.NewPostgresSessionLocker` (Postgres session-level advisory lock). Concurrent `AutoMigrate` calls from multiple replicas are now serialized at the DB level — no more races on `goose_db_version`.
- `WithDisableGlobalRegistry(true)` prevents accidental pickup of globally registered Go migrations.
- `Up` / `Down` use `Provider.Up` / `Provider.Down` and print the structured `*MigrationResult` values.
- `Redo` implemented as `Provider.Down` + `Provider.Up` (no direct method on `Provider`).
- `Status` uses `Provider.Status` → `[]*MigrationStatus` printed to stdout; replaces the old path that relied on goose's internal logger writing to stderr.
- `Versions` uses `Provider.GetVersions`; removes the private `latestEmbeddedVersion` helper and `goose.EnsureDBVersionContext`.
- `Create` unchanged — `goose.Create` is not bound to a Provider.

### `internal/migrate/migrate_test.go`

- `TestLatestEmbeddedVersion` → `TestEmbeddedMigrationsFS`: verifies the embedded `migrations.FS` has the expected number of SQL files using `fs.ReadDir` directly, no DB connection needed.

### `internal/config/config.go` + `README.md`

- `AutoMigrate` default changed **`false` → `true`**: the advisory lock makes every-replica auto-migrate safe. `URL_SHORTENER_AUTO_MIGRATE=false` opts out for explicit/audited deployments.