### PR TITLE
chore: add GitHub PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Something is broken or behaving unexpectedly
+labels: bug
+---
+
+## Describe the bug
+
+<!-- A clear and concise description of what is wrong. -->
+
+## Steps to reproduce
+
+1. 
+2. 
+3. 
+
+## Expected behaviour
+
+<!-- What you expected to happen. -->
+
+## Actual behaviour
+
+<!-- What actually happened. Include error messages, HTTP responses, or log output where relevant. -->
+
+## Environment
+
+- Version / image tag: <!-- e.g. v0.6.0 or ghcr.io/…:v0.6.0 -->
+- Deployment: <!-- docker compose / Kubernetes / bare binary -->
+- Go version (if building from source): <!-- go version -->
+
+## Additional context
+
+<!-- Anything else that might help: config snippets (redact credentials), stack traces, screenshots. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Propose a new feature or improvement
+labels: enhancement
+---
+
+## Problem / motivation
+
+<!-- What problem does this solve, or what use-case does it enable? -->
+
+## Proposed solution
+
+<!-- Describe the feature you'd like and how it should work. -->
+
+## Alternatives considered
+
+<!-- Any other approaches you evaluated and why you ruled them out. -->
+
+## Additional context
+
+<!-- Mockups, related issues, links to prior art, etc. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- What does this PR do and why? One paragraph is enough for small changes. -->
+
+## Type of change
+
+<!-- Tick whichever apply. The PR title must use the matching conventional-commit type. -->
+
+- [ ] `feat` – new user-visible feature
+- [ ] `fix` – bug fix
+- [ ] `perf` – performance improvement
+- [ ] `refactor` – code restructuring, no behaviour change
+- [ ] `docs` – documentation only
+- [ ] `test` – adding or updating tests
+- [ ] `build` / `ci` / `chore` – tooling, dependencies, CI
+
+## Checklist
+
+- [ ] `just fmt` passes (no formatting diff)
+- [ ] `just lint` passes (0 issues)
+- [ ] `just test` passes (`go test -race ./...`)
+- [ ] New behaviour is covered by tests
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): subject`)
+
+## Related issues / PRs
+
+<!-- Closes #NNN or N/A -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,7 @@
 - [ ] `just fmt` passes (no formatting diff)
 - [ ] `just lint` passes (0 issues)
 - [ ] `just test` passes (`go test -race ./...`)
+- [ ] `just test-integration` passes (if touching DB / Redis / server wiring)
 - [ ] New behaviour is covered by tests
 - [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): subject`)
 


### PR DESCRIPTION
Adds community contribution templates under `.github/`.

## PR template (`.github/pull_request_template.md`)

Pre-fills new pull requests with:
- **Summary** free-text section
- **Type of change** checklist (maps to the commitlint types enforced by CI)
- **Checklist** covering `just fmt`, `just lint`, `just test`, `just test-integration`, and test coverage
- **Related issues / PRs** field

## Issue templates (`.github/ISSUE_TEMPLATE/`)

- **`bug_report.md`** — steps to reproduce, expected vs actual behaviour, environment details
- **`feature_request.md`** — problem / motivation, proposed solution, alternatives considered