### PR TITLE
chore(web): add Prettier

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -151,6 +151,8 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           node-version: ${{ env.NODE_VERSION }}
           go-cache: "false"
+      - name: just web-fmt-check
+        run: just web-fmt-check
       - name: just web-check
         run: just web-check
 

--- a/Justfile
+++ b/Justfile
@@ -104,6 +104,18 @@ web-dev: web-install
 web-check: web-install
     npm run check
 
+# Format the web SPA with Prettier (writes files in-place).
+[group("dev")]
+[working-directory("web")]
+web-fmt: web-install
+    npm run fmt
+
+# Check web SPA formatting with Prettier (fails on diff; used by CI).
+[group("lint")]
+[working-directory("web")]
+web-fmt-check: web-install
+    npm run fmt:check
+
 # Run the binary locally.
 [group("dev")]
 run *ARGS:

--- a/web/.prettierignore
+++ b/web/.prettierignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+public/static/

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,6 +11,8 @@
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
         "@tailwindcss/vite": "^4.3.0",
         "@tsconfig/svelte": "^5.0.8",
+        "prettier": "^3.5.3",
+        "prettier-plugin-svelte": "^4.0.1",
         "redoc": "^2.5.2",
         "svelte": "^5.55.7",
         "svelte-check": "^4.4.8",
@@ -2199,6 +2201,36 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-svelte": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-4.0.1.tgz",
+      "integrity": "sha512-oDVmtKi+M8bJeUoMfPvulUqZYcuXrs5AmhhLYPKtBeg6hcpMdx7UYYisVCqEaLQuKtiPSYFpotfwp4cZK3D4xw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0",
+        "svelte": "^5.0.0"
+      }
     },
     "node_modules/prismjs": {
       "version": "1.30.0",

--- a/web/package.json
+++ b/web/package.json
@@ -10,12 +10,16 @@
     "prebuild": "npm run vendor:docs",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "svelte-check --tsconfig ./tsconfig.json"
+    "check": "svelte-check --tsconfig ./tsconfig.json",
+    "fmt": "prettier --write .",
+    "fmt:check": "prettier --check ."
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@tailwindcss/vite": "^4.3.0",
     "@tsconfig/svelte": "^5.0.8",
+    "prettier": "^3.5.3",
+    "prettier-plugin-svelte": "^4.0.1",
     "redoc": "^2.5.2",
     "svelte": "^5.55.7",
     "svelte-check": "^4.4.8",

--- a/web/prettier.config.js
+++ b/web/prettier.config.js
@@ -1,0 +1,7 @@
+/** @type {import("prettier").Config} */
+export default {
+  plugins: ["prettier-plugin-svelte"],
+  overrides: [{ files: "*.svelte", options: { parser: "svelte" } }],
+  printWidth: 100,
+  trailingComma: "es5",
+};

--- a/web/public/swagger-ui-init.js
+++ b/web/public/swagger-ui-init.js
@@ -7,10 +7,7 @@ window.addEventListener("load", function () {
     dom_id: "#swagger-ui",
     deepLinking: true,
     tryItOutEnabled: true,
-    presets: [
-      SwaggerUIBundle.presets.apis,
-      SwaggerUIStandalonePreset,
-    ],
+    presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
     layout: "StandaloneLayout",
   });
 });

--- a/web/src/lib/RecentItem.svelte
+++ b/web/src/lib/RecentItem.svelte
@@ -80,8 +80,7 @@
     class="font-mono text-sm text-indigo-600 hover:underline shrink-0 dark:text-indigo-400"
     >{current.short_url}</a
   >
-  <span
-    class="truncate text-xs sm:text-sm text-slate-500 flex-1 min-w-0 dark:text-slate-400"
+  <span class="truncate text-xs sm:text-sm text-slate-500 flex-1 min-w-0 dark:text-slate-400"
     >{current.target_url}</span
   >
   <span class="shrink-0 inline-flex flex-wrap items-center gap-1.5 text-xs">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -122,10 +122,6 @@ export async function getVersion(): Promise<VersionInfo> {
  */
 export function isApiError(err: unknown): err is ApiError {
   return (
-    typeof err === "object" &&
-    err !== null &&
-    "status" in err &&
-    "code" in err &&
-    "message" in err
+    typeof err === "object" && err !== null && "status" in err && "code" in err && "message" in err
   );
 }


### PR DESCRIPTION
## Summary

Adds [Prettier](https://prettier.io/) formatting to the Svelte 5 SPA with Svelte 5-compatible plugin support.

## Changes

- `web/prettier.config.js` — config: `prettier-plugin-svelte@^4` (Svelte 5-only), `printWidth: 100`, `trailingComma: "es5"`, Svelte parser override
- `web/.prettierignore` — excludes `dist/`, `node_modules/`, `public/static/` (vendored third-party JS)
- `web/package.json` — adds `prettier@^3` + `prettier-plugin-svelte@^4` to devDependencies; adds `fmt` (write) and `fmt:check` (CI gate) scripts
- `Justfile` — `web-fmt` (local write) and `web-fmt-check` (CI gate) recipes
- `.github/workflows/ci.yaml` — `just web-fmt-check` step added to the `web` job before `just web-check`
- 3 source files reformatted by the initial format run: `public/swagger-ui-init.js`, `src/lib/api.ts`, `src/lib/RecentItem.svelte`

## Type of change

- [x] refactor (no behaviour change)
- [x] build (changes to build system or tooling)

## Checklist

- [x] `just web-fmt-check` passes
- [x] `just web-check` passes
