### PR TITLE
refactor(web): move error mapping to api.ts

### DIFF
--- a/web/src/lib/LinkForm.svelte
+++ b/web/src/lib/LinkForm.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createLink, isApiError, type Link } from "./api";
+  import { createLink, friendlyError, type Link } from "./api";
   import { EXPIRES_PRESETS, resolveExpiresAt } from "./expires";
 
   interface Props {
@@ -32,22 +32,10 @@
       });
       await onSuccess(result);
     } catch (err) {
-      onFailure({ message: friendlyMessage(err) });
+      onFailure({ message: friendlyError(err) });
     } finally {
       pending = false;
     }
-  }
-
-  /**
-   * Translate an `ApiError` into the user-facing message strings the
-   * old Go HTML route produced. Anything outside the well-known set
-   * falls back to the server's `message` field.
-   */
-  function friendlyMessage(err: unknown): string {
-    if (!isApiError(err)) return "Request failed.";
-    if (err.code === "code_taken") return "That code is already in use.";
-    if (err.code === "internal_error") return "Something went wrong. Try again.";
-    return err.message || "Request failed.";
   }
 </script>
 

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { deleteLink, isApiError, listLinks } from "./api";
+import { deleteLink, friendlyError, isApiError, listLinks } from "./api";
 import type { Mock } from "vitest";
 
 // ---------------------------------------------------------------------------
@@ -104,5 +104,43 @@ describe("deleteLink", () => {
   it("throws an ApiError on other non-2xx responses", async () => {
     respondWith(500, { code: "internal_error", message: "server error" });
     await expect(deleteLink("abc")).rejects.toMatchObject({ status: 500 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// friendlyError — user-facing message mapping
+// ---------------------------------------------------------------------------
+
+describe("friendlyError", () => {
+  it("returns 'Request failed.' for null", () => {
+    expect(friendlyError(null)).toBe("Request failed.");
+  });
+
+  it("returns 'Request failed.' for a plain Error instance", () => {
+    expect(friendlyError(new Error("boom"))).toBe("Request failed.");
+  });
+
+  it("returns a friendly message for code_taken", () => {
+    expect(friendlyError({ status: 409, code: "code_taken", message: "taken" })).toBe(
+      "That code is already in use."
+    );
+  });
+
+  it("returns a friendly message for internal_error", () => {
+    expect(friendlyError({ status: 500, code: "internal_error", message: "error" })).toBe(
+      "Something went wrong. Try again."
+    );
+  });
+
+  it("returns the server message for unknown codes", () => {
+    expect(friendlyError({ status: 400, code: "bad_request", message: "Bad request" })).toBe(
+      "Bad request"
+    );
+  });
+
+  it("falls back to 'Request failed.' when the server message is empty", () => {
+    expect(friendlyError({ status: 400, code: "bad_request", message: "" })).toBe(
+      "Request failed."
+    );
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -125,3 +125,15 @@ export function isApiError(err: unknown): err is ApiError {
     typeof err === "object" && err !== null && "status" in err && "code" in err && "message" in err
   );
 }
+
+/**
+ * Translate an API error (or any thrown value) into a user-facing message.
+ * Well-known error codes are mapped to friendly strings; everything else
+ * falls back to the server's `message` field or a generic fallback.
+ */
+export function friendlyError(err: unknown): string {
+  if (!isApiError(err)) return "Request failed.";
+  if (err.code === "code_taken") return "That code is already in use.";
+  if (err.code === "internal_error") return "Something went wrong. Try again.";
+  return err.message || "Request failed.";
+}


### PR DESCRIPTION
## Summary

Moves the API error → user message mapping out of `LinkForm.svelte` and into a public `friendlyError()` utility in `api.ts`, making it reusable and testable.

## Changes

- `web/src/lib/api.ts` — add `export function friendlyError(err: unknown): string`: maps `code_taken` / `internal_error` to friendly strings; falls back to `err.message` or `"Request failed."`
- `web/src/lib/LinkForm.svelte` — import `friendlyError` from `api.ts`; remove inline `friendlyMessage()` function and now-unused `isApiError` import
- `web/src/lib/api.test.ts` — 6 new tests for `friendlyError`: null, plain Error, `code_taken`, `internal_error`, unknown code with message, empty message fallback

## Type of change

- [x] refactor (no behaviour change)
- [x] test (new/updated tests)

## Checklist

- [x] `just web-fmt-check` passes
- [x] `just web-lint` passes
- [x] `just web-test` passes (40/40)
- [x] `just web-check` passes
