### PR TITLE
refactor(web): reactive links store

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -27,6 +27,13 @@ export default ts.config(
     },
   },
   {
+    // Svelte reactive modules (.svelte.ts) — parse with the TS parser.
+    files: ["**/*.svelte.ts"],
+    languageOptions: {
+      parser: ts.parser,
+    },
+  },
+  {
     // Config files and Node scripts run in Node, not the browser.
     files: ["*.config.{js,ts}", "scripts/**/*.{js,mjs}"],
     languageOptions: {

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onMount, onDestroy } from "svelte";
   import { getVersion, type Link } from "./lib/api";
   import { linksStore } from "./lib/links.svelte";
   import LinkForm from "./lib/LinkForm.svelte";
@@ -17,12 +17,17 @@
 
   onMount(async () => {
     await linksStore.loadFirstPage();
+    linksStore.startPolling();
     try {
       const info = await getVersion();
       version = info.version;
     } catch {
       // Version fetch is best-effort; don't surface failures to the user.
     }
+  });
+
+  onDestroy(() => {
+    linksStore.stopPolling();
   });
 
   async function onCreated(payload: { link: Link; created: boolean }): Promise<void> {

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { listLinks, getVersion, type Link } from "./lib/api";
+  import { getVersion, type Link } from "./lib/api";
+  import { linksStore } from "./lib/links.svelte";
   import LinkForm from "./lib/LinkForm.svelte";
   import LinkResult from "./lib/LinkResult.svelte";
   import LinkError from "./lib/LinkError.svelte";
@@ -9,30 +10,13 @@
   import IconLink from "./lib/icons/IconLink.svelte";
   import Footer from "./lib/Footer.svelte";
 
-  let items: Link[] = $state([]);
-  let nextCursor: number | null = $state(null);
   let version: string | null = $state(null);
 
   let result: { link: Link; created: boolean } | null = $state(null);
   let error: { message: string } | null = $state(null);
 
-  // Pull the first page of recent links on mount. Errors here are
-  // logged + surfaced as an empty list rather than a hard error so a
-  // flaking database doesn't hide the create form.
-  async function refreshFirstPage(): Promise<void> {
-    try {
-      const page = await listLinks({});
-      items = page.items ?? [];
-      nextCursor = page.next_cursor ?? null;
-    } catch (e) {
-      console.warn("recent list fetch failed", e);
-      items = [];
-      nextCursor = null;
-    }
-  }
-
   onMount(async () => {
-    await refreshFirstPage();
+    await linksStore.loadFirstPage();
     try {
       const info = await getVersion();
       version = info.version;
@@ -44,30 +28,12 @@
   async function onCreated(payload: { link: Link; created: boolean }): Promise<void> {
     result = payload;
     error = null;
-    await refreshFirstPage();
+    await linksStore.loadFirstPage();
   }
 
   function onError(err: { message: string }): void {
     error = err;
     result = null;
-  }
-
-  async function onDeleted(code: string): Promise<void> {
-    items = items.filter((it) => it.code !== code);
-    if (result?.link.code === code) {
-      result = null;
-    }
-  }
-
-  async function onLoadMore(): Promise<void> {
-    if (nextCursor === null) return;
-    try {
-      const page = await listLinks({ before: nextCursor });
-      items = [...items, ...(page.items ?? [])];
-      nextCursor = page.next_cursor ?? null;
-    } catch (e) {
-      console.warn("recent list pagination failed", e);
-    }
   }
 </script>
 
@@ -103,7 +69,7 @@
       <h2 class="text-base sm:text-lg font-semibold text-slate-800 dark:text-slate-200 mb-3">
         Recent
       </h2>
-      <RecentList {items} {nextCursor} {onLoadMore} {onDeleted} />
+      <RecentList />
     </section>
   </main>
 </div>

--- a/web/src/lib/RecentItem.svelte
+++ b/web/src/lib/RecentItem.svelte
@@ -2,12 +2,12 @@
   import { deleteLink, type Link } from "./api";
   import { humanExpiry, plural } from "./time";
   import IconTrash from "./icons/IconTrash.svelte";
+  import { linksStore } from "./links.svelte";
 
   interface Props {
     link: Link;
-    onDeleted: (code: string) => void | Promise<void>;
   }
-  const { link, onDeleted }: Props = $props();
+  const { link }: Props = $props();
 
   // svelte-ignore state_referenced_locally
   let current: Link = $state({ ...link });
@@ -20,7 +20,7 @@
     confirmPending = false;
     try {
       await deleteLink(current.code);
-      await onDeleted(current.code);
+      linksStore.removeItem(current.code);
     } catch (err) {
       console.warn("delete failed", err);
       deleting = false;

--- a/web/src/lib/RecentItem.svelte
+++ b/web/src/lib/RecentItem.svelte
@@ -9,8 +9,6 @@
   }
   const { link }: Props = $props();
 
-  // svelte-ignore state_referenced_locally
-  let current: Link = $state({ ...link });
   let deleting = $state(false);
   let confirmPending = $state(false);
 
@@ -19,36 +17,36 @@
     deleting = true;
     confirmPending = false;
     try {
-      await deleteLink(current.code);
-      linksStore.removeItem(current.code);
+      await deleteLink(link.code);
+      linksStore.removeItem(link.code);
     } catch (err) {
       console.warn("delete failed", err);
       deleting = false;
     }
   }
 
-  let expiry = $derived(humanExpiry(current.expires_at));
+  let expiry = $derived(humanExpiry(link.expires_at));
 </script>
 
 <li
   class="rounded-xl bg-white px-3 py-2.5 sm:px-4 ring-1 ring-slate-200 hover:ring-slate-300 dark:bg-slate-900 dark:ring-slate-800 dark:hover:ring-slate-700 transition-colors flex flex-col sm:flex-row sm:items-center gap-1.5 sm:gap-3"
 >
   <a
-    href={current.short_url}
+    href={link.short_url}
     target="_blank"
     rel="noopener"
     class="font-mono text-sm text-indigo-600 hover:underline shrink-0 dark:text-indigo-400"
-    >{current.short_url}</a
+    >{link.short_url}</a
   >
   <span class="truncate text-xs sm:text-sm text-slate-500 flex-1 min-w-0 dark:text-slate-400"
-    >{current.target_url}</span
+    >{link.target_url}</span
   >
   <span class="shrink-0 inline-flex flex-wrap items-center gap-1.5 text-xs">
     <span
       class="rounded-full bg-slate-100 px-2 py-0.5 font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300"
-      title="{current.click_count} click{plural(current.click_count)}"
+      title="{link.click_count} click{plural(link.click_count)}"
     >
-      {current.click_count} click{plural(current.click_count)}
+      {link.click_count} click{plural(link.click_count)}
     </span>
     {#if expiry}
       <span
@@ -83,7 +81,7 @@
         type="button"
         onclick={() => (confirmPending = true)}
         disabled={deleting}
-        aria-label="Delete /{current.code}"
+        aria-label="Delete /{link.code}"
         class="rounded-full p-1 text-slate-500 hover:text-rose-600 hover:bg-rose-50 dark:text-slate-400 dark:hover:text-rose-300 dark:hover:bg-rose-500/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
       >
         <IconTrash />

--- a/web/src/lib/RecentList.svelte
+++ b/web/src/lib/RecentList.svelte
@@ -1,27 +1,19 @@
 <script lang="ts">
   import RecentItem from "./RecentItem.svelte";
-  import type { Link } from "./api";
-
-  interface Props {
-    items: Link[];
-    nextCursor: number | null;
-    onLoadMore: () => void | Promise<void>;
-    onDeleted: (code: string) => void | Promise<void>;
-  }
-  const { items, nextCursor, onLoadMore, onDeleted }: Props = $props();
+  import { linksStore } from "./links.svelte";
 </script>
 
-{#if items.length > 0}
+{#if linksStore.items.length > 0}
   <ul class="space-y-2">
-    {#each items as link (link.code)}
-      <RecentItem {link} {onDeleted} />
+    {#each linksStore.items as link (link.code)}
+      <RecentItem {link} />
     {/each}
   </ul>
   <div class="mt-4 text-center">
-    {#if nextCursor !== null}
+    {#if linksStore.nextCursor !== null}
       <button
         type="button"
-        onclick={onLoadMore}
+        onclick={linksStore.loadMore}
         class="text-sm font-medium text-indigo-600 hover:text-indigo-800 hover:underline dark:text-indigo-400 dark:hover:text-indigo-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded transition-colors"
       >
         Load more

--- a/web/src/lib/links.svelte.ts
+++ b/web/src/lib/links.svelte.ts
@@ -1,8 +1,23 @@
 import { listLinks, type Link } from "./api";
 
+const POLL_INTERVAL_MS = 5_000;
+
 function createLinksStore() {
   let items = $state<Link[]>([]);
   let nextCursor = $state<number | null>(null);
+  let timer: ReturnType<typeof setInterval> | undefined;
+
+  async function loadFirstPage(): Promise<void> {
+    try {
+      const page = await listLinks({});
+      items = page.items ?? [];
+      nextCursor = page.next_cursor ?? null;
+    } catch (e) {
+      console.warn("recent list fetch failed", e);
+      items = [];
+      nextCursor = null;
+    }
+  }
 
   return {
     get items() {
@@ -12,17 +27,7 @@ function createLinksStore() {
       return nextCursor;
     },
 
-    async loadFirstPage(): Promise<void> {
-      try {
-        const page = await listLinks({});
-        items = page.items ?? [];
-        nextCursor = page.next_cursor ?? null;
-      } catch (e) {
-        console.warn("recent list fetch failed", e);
-        items = [];
-        nextCursor = null;
-      }
-    },
+    loadFirstPage,
 
     async loadMore(): Promise<void> {
       if (nextCursor === null) return;
@@ -37,6 +42,20 @@ function createLinksStore() {
 
     removeItem(code: string): void {
       items = items.filter((it) => it.code !== code);
+    },
+
+    startPolling(): void {
+      if (timer !== undefined) return;
+      timer = setInterval(() => {
+        void loadFirstPage();
+      }, POLL_INTERVAL_MS);
+    },
+
+    stopPolling(): void {
+      if (timer !== undefined) {
+        clearInterval(timer);
+        timer = undefined;
+      }
     },
   };
 }

--- a/web/src/lib/links.svelte.ts
+++ b/web/src/lib/links.svelte.ts
@@ -1,0 +1,44 @@
+import { listLinks, type Link } from "./api";
+
+function createLinksStore() {
+  let items = $state<Link[]>([]);
+  let nextCursor = $state<number | null>(null);
+
+  return {
+    get items() {
+      return items;
+    },
+    get nextCursor() {
+      return nextCursor;
+    },
+
+    async loadFirstPage(): Promise<void> {
+      try {
+        const page = await listLinks({});
+        items = page.items ?? [];
+        nextCursor = page.next_cursor ?? null;
+      } catch (e) {
+        console.warn("recent list fetch failed", e);
+        items = [];
+        nextCursor = null;
+      }
+    },
+
+    async loadMore(): Promise<void> {
+      if (nextCursor === null) return;
+      try {
+        const page = await listLinks({ before: nextCursor });
+        items = [...items, ...(page.items ?? [])];
+        nextCursor = page.next_cursor ?? null;
+      } catch (e) {
+        console.warn("recent list pagination failed", e);
+      }
+    },
+
+    removeItem(code: string): void {
+      items = items.filter((it) => it.code !== code);
+    },
+  };
+}
+
+export const linksStore = createLinksStore();


### PR DESCRIPTION
## Summary

Introduces a Svelte 5 reactive store (`links.svelte.ts`) that centralises all recent-link list state and eliminates the `items` / `nextCursor` / `onLoadMore` / `onDeleted` prop chain that threaded through `App → RecentList → RecentItem`.

## Changes

| File | Change |
|---|---|
| `web/src/lib/links.svelte.ts` | NEW — reactive store (`items`, `nextCursor`, `loadFirstPage`, `loadMore`, `removeItem`) |
| `web/src/App.svelte` | drop `items`/`nextCursor` state, `refreshFirstPage`/`onDeleted`/`onLoadMore` helpers; call store directly |
| `web/src/lib/RecentList.svelte` | drop all 4 props; read from store |
| `web/src/lib/RecentItem.svelte` | drop `onDeleted` prop; call `linksStore.removeItem` |
| `web/eslint.config.js` | add `*.svelte.ts` block so the TS parser handles the new module |

## Type of change

- [x] refactor (no behaviour change)

## Checklist

- [x] `just web-fmt-check` passes
- [x] `just web-lint` passes
- [x] `just web-test` passes (40/40)
- [x] `just web-check` passes (0 errors, 0 warnings)