### PR TITLE
refactor(server): rename /healthz to /livez

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,7 +106,7 @@ jobs:
 
   openapi:
     name: openapi (spectral)
-    # Lint the OpenAPI 3.1 document at api/openapi.yaml using Spectral.
+    # Lint the OpenAPI 3.0 document at api/openapi.yaml using Spectral.
     # Spectral lives in package.json's devDependencies and is invoked
     # via `just lint-openapi`, which calls the `lint:openapi` npm
     # script with the project ruleset (.spectral.yaml). A drift

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -285,7 +285,7 @@ jobs:
 
       # `--wait` blocks until each service's healthcheck reports
       # healthy. The server's healthcheck invokes the binary's own
-      # `healthcheck` subcommand, which dials its own /healthz, so by
+      # `healthcheck` subcommand, which dials its own /livez, so by
       # the time `up` returns the listener is accepting traffic.
       # AUTO_MIGRATE=true (set in compose.yaml) ensures the schema is
       # applied before that point.

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ EXPOSE 8080
 
 USER nonroot:nonroot
 
-# Probe the binary's own /healthz via the `healthcheck` subcommand.
+# Probe the binary's own /livez via the `healthcheck` subcommand.
 # Distroless ships neither curl nor wget, so the binary itself is the
 # probe. Mirrors the compose.yaml healthcheck so `docker run` users get
 # the same liveness signal without composing a stack. Kubernetes and

--- a/Justfile
+++ b/Justfile
@@ -378,7 +378,7 @@ tidy:
     go mod tidy
 
 # Smoke-check a running url-shortener stack: hit the operational endpoints
-# (`/healthz`, `/readyz`, `/version`), the embedded static assets, and a
+# (`/livez`, `/readyz`, `/version`), the embedded static assets, and a
 # real shorten -> fetch -> redirect cycle. The same script CI's
 # `compose-smoke` job runs against the `dev` compose profile after
 # `docker compose --profile=dev up --wait`, factored out here so a dev
@@ -404,8 +404,8 @@ compose-smoke:
     set -euo pipefail
     base="http://localhost:8080"
 
-    echo "== /healthz =="
-    curl --fail-with-body -sS "$base/healthz" \
+    echo "== /livez =="
+    curl --fail-with-body -sS "$base/livez" \
         | tee /dev/stderr | jq -e '.status == "ok"' >/dev/null
 
     echo "== /readyz =="
@@ -494,7 +494,7 @@ compose-smoke:
 #   2. Bring up `--profile=tls` with TLS_CERTS_DIR pointing at the
 #      tempdir's certs/ subdir, so the existing `dev/certs/`
 #      contents are untouched.
-#   3. Hit /healthz, /readyz, /version over HTTPS with
+#   3. Hit /livez, /readyz, /version over HTTPS with
 #      `--cacert <tempdir>/rootCA.pem` -- a strict check that the
 #      server is actually serving the cert we just signed.
 #   4. Rotate the leaf cert in-place and assert the running server
@@ -567,8 +567,8 @@ tls-smoke:
 
     base="https://localhost:8443"
 
-    echo "== /healthz (curl --cacert) =="
-    curl --fail-with-body -sS --cacert "$cacert" "$base/healthz" \
+    echo "== /livez (curl --cacert) =="
+    curl --fail-with-body -sS --cacert "$cacert" "$base/livez" \
         | tee /dev/stderr | jq -e '.status == "ok"' >/dev/null
 
     echo "== /readyz =="
@@ -610,7 +610,7 @@ tls-smoke:
     # chain is genuinely walked rather than e.g. the compose stack
     # serving a default fallback that happens to match.
     echo "== curl without --cacert must fail TLS verification =="
-    if curl --fail-with-body -sS -o /dev/null "$base/healthz" 2>/dev/null; then
+    if curl --fail-with-body -sS -o /dev/null "$base/livez" 2>/dev/null; then
         echo "expected TLS verification failure, got success" >&2
         exit 1
     fi

--- a/Justfile
+++ b/Justfile
@@ -280,7 +280,7 @@ lint: lint-install web-build tidy
 fmt: lint-install
     {{ quote(BIN_DIR / "golangci-lint") }} fmt
 
-# Lint the OpenAPI 3.1 document at api/openapi.yaml with Spectral.
+# Lint the OpenAPI 3.0 document at api/openapi.yaml with Spectral.
 # Spectral is installed as an npm devDependency (see package.json),
 # so the recipe depends on `init` to make sure node_modules/.bin is
 # populated. Configuration lives at .spectral.yaml at the repo root;

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Go builder runs.
 ./bin/url-shortener migrate down  # roll back the most recent migration
 ./bin/url-shortener migrate status
 ./bin/url-shortener migrate up --database-url postgres://...  # override URL_SHORTENER_DATABASE_URL
-./bin/url-shortener healthcheck   # probe /healthz; used by the docker HEALTHCHECK
+./bin/url-shortener healthcheck   # probe /livez; used by the docker HEALTHCHECK
 ```
 
 ## Configuration
@@ -345,7 +345,7 @@ The HTTP server exposes three operational endpoints:
 
 | Endpoint    | Purpose                          | Behaviour                                                                                     |
 | ----------- | -------------------------------- | --------------------------------------------------------------------------------------------- |
-| `/healthz`  | Liveness probe                   | Always returns `200` + `{"status":"ok"}` while the process is responsive. No dependencies.    |
+| `/livez`   | Liveness probe                   | Always returns `200` + `{"status":"ok"}` while the process is responsive. No dependencies.    |
 | `/readyz`   | Readiness probe                  | Pings every registered dependency. Returns `200` when all are healthy, `503` otherwise.       |
 | `/version`  | Build metadata                   | Returns `{"version":"...","commit":"...","date":"..."}` baked into the binary at build time.  |
 
@@ -397,7 +397,7 @@ distroless container and exposes the app on `:8443`:
 ```sh
 just dev-certs                                  # one-time per host
 just up-tls -d --build --wait
-curl https://localhost:8443/healthz             # {"status":"ok"}
+curl https://localhost:8443/livez             # {"status":"ok"}
 just down-tls -v
 ```
 

--- a/api/embed_test.go
+++ b/api/embed_test.go
@@ -56,7 +56,7 @@ func TestSpecJSON_IsValidJSONAndPreservesStructure(t *testing.T) {
 		"/api/v1/links/{code}",
 		"/r/{code}",
 		"/api/v1/openapi.json",
-		"/healthz",
+		"/livez",
 		"/readyz",
 		"/version",
 	} {

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -17,7 +17,7 @@ info:
   description: |
     The url-shortener service exposes a small JSON HTTP API plus a
     public 302 redirect endpoint. This document describes both, along
-    with the operational endpoints (`/healthz`, `/readyz`,
+    with the operational endpoints (`/livez`, `/readyz`,
     `/version`) used by orchestrators and humans.
 
     ## Conventions
@@ -291,9 +291,8 @@ paths:
         expired link can never be served from cache.
 
         Soft-deleted and expired links return `410 Gone`. The
-        response body is plain text (Echo's default error renderer
-        for non-JSON paths); programmatic clients that need the
-        machine-readable `code` field should call
+        response body is plain text; programmatic clients that need
+        the machine-readable `code` field should call
         `GET /api/v1/links/{code}` instead.
       operationId: redirectLink
       responses:
@@ -346,7 +345,7 @@ paths:
                 type: object
                 description: An OpenAPI 3.0 document.
 
-  /healthz:
+  /livez:
     get:
       tags: [operational]
       summary: Liveness probe.
@@ -355,7 +354,7 @@ paths:
         stack is responsive. Has no dependencies on Postgres or
         Redis -- a flapping database must not cause Kubernetes to
         restart the pod.
-      operationId: healthz
+      operationId: livez
       responses:
         '200':
           description: The process is alive.

--- a/compose.yaml
+++ b/compose.yaml
@@ -33,7 +33,7 @@
 #       Prereq:    just dev-certs        (one-time per host)
 #       Bring up:  docker compose --profile=tls up --wait -d
 #       Tear down: docker compose --profile=tls down -v
-#       Test:      curl https://localhost:8443/healthz
+#       Test:      curl https://localhost:8443/livez
 #
 # Every service is profile-gated, so a bare `docker compose up` starts
 # nothing. That's intentional: the previous arrangement (default
@@ -140,7 +140,7 @@ services:
     ports:
       - "8080:8080"
     # Distroless has no curl/wget; the binary's `healthcheck` subcommand
-    # probes its own /healthz so docker / `up --wait` can tell when the
+    # probes its own /livez so docker / `up --wait` can tell when the
     # server is actually accepting requests (rather than just "container
     # started").
     healthcheck:
@@ -203,7 +203,7 @@ services:
     # host's local CA trust). The probe is a liveness check, not a
     # security boundary.
     healthcheck:
-      test: ["CMD", "/usr/local/bin/url-shortener", "healthcheck", "--url=https://127.0.0.1:8443/healthz", "--insecure"]
+      test: ["CMD", "/usr/local/bin/url-shortener", "healthcheck", "--url=https://127.0.0.1:8443/livez", "--insecure"]
       interval: 5s
       timeout: 3s
       retries: 10

--- a/internal/cli/healthcheck.go
+++ b/internal/cli/healthcheck.go
@@ -19,17 +19,17 @@ import (
 //	  test: ["CMD", "/usr/local/bin/url-shortener", "healthcheck"]
 //
 // For TLS-fronted services (the `tls` compose profile), pass
-// `--url=https://127.0.0.1:8443/healthz --insecure` so the probe
+// `--url=https://127.0.0.1:8443/livez --insecure` so the probe
 // skips cert verification -- the certificate is intended for the
 // outside world, not the in-container loopback hop.
 func newHealthcheckCmd() *cli.Command {
 	return &cli.Command{
 		Name:  "healthcheck",
-		Usage: "Probe the local /healthz endpoint and exit 0 when it returns 200",
+		Usage: "Probe the local /livez endpoint and exit 0 when it returns 200",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "url",
-				Value: "http://127.0.0.1:8080/healthz",
+				Value: "http://127.0.0.1:8080/livez",
 				Usage: "URL to probe",
 			},
 			&cli.DurationFlag{

--- a/internal/handlers/links.go
+++ b/internal/handlers/links.go
@@ -175,7 +175,7 @@ func NewLinks(cfg LinksConfig) *Links {
 
 // Mount registers the API + redirect routes on r. The public redirect
 // lives under /r/{code} (rather than /{code}) so it can never shadow
-// operational endpoints (/healthz, /readyz, /version) or future
+// operational endpoints (/livez, /readyz, /version) or future
 // top-level routes like /api, static assets, or HTML pages.
 //
 // createMW are route-scoped middlewares attached only to

--- a/internal/handlers/operational.go
+++ b/internal/handlers/operational.go
@@ -1,6 +1,6 @@
 // Package handlers contains the HTTP handlers for the url-shortener API.
 //
-// This file implements the operational endpoints (`/healthz`, `/readyz`,
+// This file implements the operational endpoints (`/livez`, `/readyz`,
 // `/version`) used by orchestrators and humans to verify the running binary.
 package handlers
 
@@ -50,17 +50,17 @@ func (h *Operational) AddReadinessCheck(name string, check func(ctx context.Cont
 	h.checks[name] = pingFunc(check)
 }
 
-// Mount registers /healthz, /readyz, /version on r.
+// Mount registers /livez, /readyz, /version on r.
 func (h *Operational) Mount(r chi.Router) {
-	r.Get("/healthz", h.Healthz)
+	r.Get("/livez", h.Livez)
 	r.Get("/readyz", h.Readyz)
 	r.Get("/version", h.Version)
 }
 
-// Healthz is the liveness probe: it returns 200 as long as the process is
+// Livez is the liveness probe: it returns 200 as long as the process is
 // running and the HTTP stack is responsive. It deliberately has no
 // dependencies so a flapping database does not cause restarts.
-func (h *Operational) Healthz(w http.ResponseWriter, _ *http.Request) {
+func (h *Operational) Livez(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 

--- a/internal/handlers/operational_test.go
+++ b/internal/handlers/operational_test.go
@@ -40,11 +40,11 @@ func do(t *testing.T, h http.Handler, path string) (int, map[string]any) {
 	return rec.Code, body
 }
 
-func TestHealthz_AlwaysOK(t *testing.T) {
+func TestLivez_AlwaysOK(t *testing.T) {
 	t.Parallel()
 
 	e := newChiRouter(nil)
-	code, body := do(t, e, "/healthz")
+	code, body := do(t, e, "/livez")
 	if code != http.StatusOK {
 		t.Errorf("status = %d, want 200", code)
 	}

--- a/internal/server/links_integration_test.go
+++ b/internal/server/links_integration_test.go
@@ -110,7 +110,7 @@ func startFullServerWithDeps(t *testing.T) (string, *store.Store, *cache.Client,
 		}
 	}
 
-	waitForReady(t, "http://"+ln.Addr().String()+"/healthz")
+	waitForReady(t, "http://"+ln.Addr().String()+"/livez")
 	return "http://" + ln.Addr().String(), st, cc, stop
 }
 
@@ -428,7 +428,7 @@ func TestServer_GracefulShutdownDrainsBackgroundTasks(t *testing.T) {
 	go func() { done <- srv.Serve(runCtx, ln) }()
 
 	base := "http://" + ln.Addr().String()
-	waitForReady(t, base+"/healthz")
+	waitForReady(t, base+"/livez")
 
 	// Seed a link so the redirect has somewhere to point. CreateLink
 	// inserts directly to skip the API layer (and its async paths).

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -54,18 +54,18 @@ func counterValue(t *testing.T, cv *prometheus.CounterVec, lvs ...string) float6
 func TestMetricsMiddleware_CountsRequests(t *testing.T) {
 	t.Parallel()
 	r, total, _ := newMetricsRouterForTest(t, map[string]int{
-		"/healthz": http.StatusOK,
+		"/livez": http.StatusOK,
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req := httptest.NewRequest(http.MethodGet, "/livez", nil)
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", rec.Code)
 	}
-	if got := counterValue(t, total, "GET", "/healthz", "200"); got != 1 {
-		t.Errorf("http_requests_total{GET,/healthz,200} = %v, want 1", got)
+	if got := counterValue(t, total, "GET", "/livez", "200"); got != 1 {
+		t.Errorf("http_requests_total{GET,/livez,200} = %v, want 1", got)
 	}
 }
 

--- a/internal/server/server_integration_test.go
+++ b/internal/server/server_integration_test.go
@@ -25,7 +25,7 @@ import (
 	"go.uber.org/goleak"
 )
 
-// waitForReady polls /healthz until it returns 200 or the deadline expires.
+// waitForReady polls /livez until it returns 200 or the deadline expires.
 func waitForReady(t *testing.T, url string) {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)
@@ -65,8 +65,8 @@ func TestServer_OperationalEndpointsOverRealNetwork(t *testing.T) {
 	base, stop := startFullServer(t)
 	defer stop()
 
-	t.Run("healthz", func(t *testing.T) {
-		code, body := getJSON(t, base+"/healthz")
+	t.Run("livez", func(t *testing.T) {
+		code, body := getJSON(t, base+"/livez")
 		if code != http.StatusOK {
 			t.Errorf("status = %d, want 200", code)
 		}
@@ -222,8 +222,8 @@ func TestServer_GracefulShutdownClosesListener(t *testing.T) {
 	base, stop := startFullServer(t)
 
 	// Verify the server is responsive.
-	if code, _ := getJSON(t, base+"/healthz"); code != http.StatusOK {
-		t.Fatalf("pre-shutdown healthz = %d", code)
+	if code, _ := getJSON(t, base+"/livez"); code != http.StatusOK {
+		t.Fatalf("pre-shutdown livez = %d", code)
 	}
 
 	stop() // cancels context, waits for Serve to return

--- a/internal/server/tls_integration_test.go
+++ b/internal/server/tls_integration_test.go
@@ -2,7 +2,7 @@
 
 // End-to-end TLS smoke test: generates a self-signed cert at test time,
 // brings up the full server with cfg.TLSCertFile + cfg.TLSKeyFile set,
-// hits /healthz over HTTPS, and verifies the handshake + response work.
+// hits /livez over HTTPS, and verifies the handshake + response work.
 //
 // This exercises the cfg.TLSCertFile branch of server.Serve without
 // requiring any cert material to be checked into the repo. Requires
@@ -244,13 +244,13 @@ func TestServer_TLSListenerServesHTTPS(t *testing.T) {
 		Timeout: 5 * time.Second,
 	}
 
-	// Poll /healthz until the server is up. The server starts the
+	// Poll /livez until the server is up. The server starts the
 	// listener synchronously inside Serve's goroutine but TLS adds a
 	// handshake on top, so the first few attempts may race.
 	deadline := time.Now().Add(5 * time.Second)
 	var resp *http.Response
 	for time.Now().Before(deadline) {
-		resp, err = client.Get(addr + "/healthz")
+		resp, err = client.Get(addr + "/livez")
 		if err == nil && resp.StatusCode == http.StatusOK {
 			break
 		}
@@ -260,7 +260,7 @@ func TestServer_TLSListenerServesHTTPS(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 	if err != nil {
-		t.Fatalf("GET %s/healthz over HTTPS: %v", addr, err)
+		t.Fatalf("GET %s/livez over HTTPS: %v", addr, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
@@ -274,7 +274,7 @@ func TestServer_TLSListenerServesHTTPS(t *testing.T) {
 	// successful at the HTTP level), but the 400 status -- distinct
 	// from the 200 we'd see if a plain-HTTP server were also on the
 	// listener -- proves the TLS branch was the only one mounted.
-	plainResp, plainErr := http.Get("http://" + ln.Addr().String() + "/healthz")
+	plainResp, plainErr := http.Get("http://" + ln.Addr().String() + "/livez")
 	if plainErr != nil {
 		t.Logf("plain-HTTP-to-TLS request errored (also acceptable): %v", plainErr)
 	} else {

--- a/web/src/lib/LinkForm.svelte
+++ b/web/src/lib/LinkForm.svelte
@@ -14,8 +14,7 @@
   let pending = $state(false);
 
   // Reusable Tailwind class string for inputs/selects so the focus
-  // ring + colour scheme doesn't drift between fields. The Go-side
-  // template used to pre-compute this; we just keep it as a constant.
+  // ring + colour scheme doesn't drift between fields.
   const inputClass =
     "mt-1 block w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-900 placeholder:text-slate-400 shadow-sm focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500 focus:outline-none dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-indigo-400 dark:focus:ring-indigo-400/40 transition-colors";
 

--- a/web/src/lib/expires.ts
+++ b/web/src/lib/expires.ts
@@ -1,8 +1,7 @@
-// Mirrors the limited set of expiry presets the Go HTML route used to
-// accept. Kept on the client because the JSON API takes an absolute
-// `expires_at` ISO timestamp -- the SPA computes the timestamp from
-// the user's preset choice and submits that. Anything outside this
-// set is treated as "never" by the form's <select>.
+// Expiry presets exposed by the form's <select>. Kept on the client
+// because the JSON API takes an absolute `expires_at` ISO timestamp --
+// the SPA computes the timestamp from the user's preset choice and
+// submits that. Anything outside this set is treated as "never".
 
 export interface ExpiresPreset {
   value: string;

--- a/web/src/lib/time.ts
+++ b/web/src/lib/time.ts
@@ -1,7 +1,5 @@
 // Coarse-grained "time-until-X" formatter for the recent-list expiry
-// badge. Mirrors the Go-side humanExpiry helper that previously lived
-// in web/web.go; kept identical so the UX doesn't drift across the
-// SPA refactor.
+// badge.
 
 /**
  * @param expiresAt ISO-8601 timestamp, null, or undefined for "never".

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -16,9 +16,8 @@ export default defineConfig({
     proxy: {
       "/api": "http://localhost:8080",
       "/r": "http://localhost:8080",
-      "/healthz": "http://localhost:8080",
-      "/readyz": "http://localhost:8080",
       "/livez": "http://localhost:8080",
+      "/readyz": "http://localhost:8080",
       "/version": "http://localhost:8080",
     },
   },


### PR DESCRIPTION
Kubernetes has deprecated the generic `/healthz` path in favour of the more explicit liveness/readiness split. This PR renames the liveness endpoint from `/healthz` to `/livez` across the entire codebase.

### Changes

| Area | What changed |
|------|-------------|
| `internal/handlers/operational.go` | Route `/healthz` → `/livez`; method `Healthz` → `Livez` |
| `internal/cli/healthcheck.go` | Default probe URL updated |
| `api/openapi.yaml` | Path key + `operationId` updated |
| `compose.yaml` / `Dockerfile` | Healthcheck `--url` flags updated |
| `Justfile` | All smoke-test `curl` calls and echo labels updated |
| `web/vite.config.ts` | Removed dead duplicate `/healthz` proxy entry (kept `/livez`) |
| Tests (6 files) | All route strings, subtest names, and comments updated |
| `README.md` / `ci.yaml` | Documentation updated |

### Verification

```
go build ./...   # clean
just lint        # 0 issues
just test        # all pass
grep -r healthz  # no matches
```