### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/actions/setup-toolchain/action.yaml
+++ b/.github/actions/setup-toolchain/action.yaml
@@ -20,13 +20,13 @@ runs:
     # Install mise and all tools declared in mise.toml (go, node, java).
     # cache: true (the default) stores ~/.local/share/mise/installs in GitHub's
     # cache so binaries are not re-downloaded on subsequent runs.
-    - uses: jdx/mise-action@v3
+    - uses: jdx/mise-action@v4
       with:
         cache: true
 
     - name: Cache Go modules
       if: ${{ inputs.go-cache == 'true' }}
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/go/pkg/mod
@@ -36,7 +36,7 @@ runs:
           go-${{ runner.os }}-
 
     - name: Cache npm packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.npm
         key: npm-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -166,7 +166,7 @@ jobs:
       # own builder stages handle Go + npm) and `mise run trivy-install`
       # (self-installs trivy into $HOME/.local/bin via BIN_DIR). The
       # host only needs Docker (preinstalled) and mise.
-      - uses: jdx/mise-action@v3
+      - uses: jdx/mise-action@v4
         with:
           cache: true
       # Build the host-arch image and scan it with Trivy. The task
@@ -241,7 +241,7 @@ jobs:
       # The smoke-check script is encapsulated in a mise task
       # (`mise run compose-smoke`) so dev iteration doesn't need a CI
       # round-trip.
-      - uses: jdx/mise-action@v3
+      - uses: jdx/mise-action@v4
         with:
           cache: true
 
@@ -296,7 +296,7 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-      - uses: jdx/mise-action@v3
+      - uses: jdx/mise-action@v4
         with:
           cache: true
       # mkcert is preinstalled on `ubuntu-latest` (`ubuntu-24.04`)

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -70,7 +70,7 @@ jobs:
       - uses: ./.github/actions/setup-toolchain
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@c3f298df8c1fea2fefe20c785e6aa00f32df8260 # v4.35.3
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           languages: ${{ matrix.language }}
           # `security-extended` adds higher-precision queries beyond
@@ -90,9 +90,9 @@ jobs:
         run: mise run web-build
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@c3f298df8c1fea2fefe20c785e6aa00f32df8260 # v4.35.3
+        uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@c3f298df8c1fea2fefe20c785e6aa00f32df8260 # v4.35.3
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/nightly-scan.yaml
+++ b/.github/workflows/nightly-scan.yaml
@@ -78,7 +78,7 @@ jobs:
       # BIN_DIR -- no Go/Node toolchain needed on the host. Trivy
       # pulls the image directly from GHCR via OCI, so the runner's
       # preinstalled Docker daemon is also unused here.
-      - uses: jdx/mise-action@v3
+      - uses: jdx/mise-action@v4
         with:
           cache: true
 


### PR DESCRIPTION
Bump pinned GitHub Actions to their latest releases.

| Action | Old | New |
|---|---|---|
| `actions/cache` | v4 | v5 |
| `jdx/mise-action` | v3 | v4 |
| `github/codeql-action` | v4.35.3 | v4.36.0 |

All other actions (`actions/checkout`, `actions/upload-artifact`, `step-security/harden-runner`, `docker/*`) are already at their latest versions.