### PR TITLE
chore(security): tighten input and config validation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"github.com/caarlos0/env/v11"
+	"github.com/jackc/pgx/v5"
+	"github.com/redis/go-redis/v9"
 )
 
 // EnvPrefix is the prefix applied to every environment variable.
@@ -186,11 +188,20 @@ func (c Config) Validate() error {
 	if c.DatabaseURL == "" {
 		return fmt.Errorf("config: database_url must not be empty")
 	}
+	// Parse the DSN now so a typo (missing scheme, bad port, unbalanced
+	// quote) surfaces as a clear validation error instead of as the first
+	// pool-acquire attempt failing with a less obvious message.
+	if _, err := pgx.ParseConfig(c.DatabaseURL); err != nil {
+		return fmt.Errorf("config: database_url: %w", err)
+	}
 	// Redis is a required runtime dependency: the cache is on the hot path
 	// for redirect lookups and the API treats it as always-present. Refuse
 	// to start instead of silently degrading.
 	if c.RedisURL == "" {
 		return fmt.Errorf("config: redis_url must not be empty")
+	}
+	if _, err := redis.ParseURL(c.RedisURL); err != nil {
+		return fmt.Errorf("config: redis_url: %w", err)
 	}
 
 	// Pool tunables: any explicit value must be non-negative; when both

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -184,6 +184,8 @@ func TestValidate_RejectsBadValues(t *testing.T) {
 		"empty baseurl":      {Env: "prod", Addr: ":8080", BaseURL: "", LogLevel: "info", LogFormat: "json", DatabaseURL: databaseURL, RedisURL: redisURL},
 		"empty database_url": {Env: "prod", Addr: ":8080", BaseURL: "x", LogLevel: "info", LogFormat: "json", DatabaseURL: "", RedisURL: redisURL},
 		"empty redis_url":    {Env: "prod", Addr: ":8080", BaseURL: "x", LogLevel: "info", LogFormat: "json", DatabaseURL: databaseURL, RedisURL: ""},
+		"bad database_url":   {Env: "prod", Addr: ":8080", BaseURL: "x", LogLevel: "info", LogFormat: "json", DatabaseURL: "::not a dsn::", RedisURL: redisURL},
+		"bad redis_url":      {Env: "prod", Addr: ":8080", BaseURL: "x", LogLevel: "info", LogFormat: "json", DatabaseURL: databaseURL, RedisURL: "::not a url::"},
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/handlers/links_service.go
+++ b/internal/handlers/links_service.go
@@ -274,6 +274,12 @@ func isPrivateHost(host string) bool {
 		// Strip the brackets so net.ParseIP can handle it.
 		hostname = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
 	}
+	// Drop any IPv6 zone identifier (e.g. "fe80::1%eth0"); ParseIP
+	// rejects scoped addresses, but the scope is meaningless in a URL
+	// and stripping it lets the link-local check below catch it.
+	if i := strings.Index(hostname, "%"); i >= 0 {
+		hostname = hostname[:i]
+	}
 	if strings.EqualFold(hostname, "localhost") {
 		return true
 	}

--- a/internal/handlers/normalize_internal_test.go
+++ b/internal/handlers/normalize_internal_test.go
@@ -110,6 +110,8 @@ func TestIsPrivateHost(t *testing.T) {
 
 		// IPv6 link-local
 		{"fe80::1", true},
+		{"fe80::1%eth0", true},     // link-local with zone identifier
+		{"[fe80::1%25eth0]", true}, // bracketed + percent-encoded zone
 
 		// IPv6 unique-local
 		{"fd00::1", true},

--- a/internal/server/proxy.go
+++ b/internal/server/proxy.go
@@ -49,10 +49,16 @@ func buildIPExtractor(trustedProxies []string) func(r *http.Request) string {
 
 		if trusted {
 			if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-				// Take the leftmost (client-provided) IP.
+				// Take the leftmost (client-provided) IP. A header value may
+				// be space-padded or contain garbage if an upstream proxy
+				// passed through a malformed value -- only return it if it
+				// parses as a real IP. Otherwise fall through to RemoteAddr
+				// so the rate-limit key is still well-formed.
 				parts := strings.SplitN(xff, ",", 2)
 				if ip := strings.TrimSpace(parts[0]); ip != "" {
-					return ip
+					if net.ParseIP(ip) != nil {
+						return ip
+					}
 				}
 			}
 		}

--- a/internal/server/proxy_test.go
+++ b/internal/server/proxy_test.go
@@ -80,6 +80,18 @@ func TestBuildIPExtractor(t *testing.T) {
 				xff:        "203.0.113.42",
 				want:       "198.51.100.7",
 			},
+			{
+				name:       "trusted peer + malformed XFF -> RemoteAddr (XFF rejected)",
+				remoteAddr: "127.0.0.1:54321",
+				xff:        "not-an-ip",
+				want:       "127.0.0.1",
+			},
+			{
+				name:       "trusted peer + IPv6 XFF -> client from XFF",
+				remoteAddr: "127.0.0.1:54321",
+				xff:        "2001:db8::1",
+				want:       "2001:db8::1",
+			},
 		}
 
 		for _, tc := range cases {


### PR DESCRIPTION
Phase A of the post-review hardening plan.

**Changes:**
- `internal/server/proxy.go` — validate the leftmost X-Forwarded-For token via `net.ParseIP` before using it as the real client IP. Garbage values from a misconfigured upstream now fall through to `RemoteAddr` instead of poisoning the rate-limit key.
- `internal/config/config.go` — parse `DATABASE_URL` with `pgx.ParseConfig` and `REDIS_URL` with `redis.ParseURL` during `Validate()` so DSN typos surface as a clear startup error instead of as the first connection attempt to fail.
- `internal/handlers/links_service.go` — strip IPv6 zone identifiers (e.g. `fe80::1%eth0`, `[fe80::1%25eth0]`) before the SSRF private-range check so scoped link-local addresses can't bypass it.

**Tests:** added cases for malformed XFF, IPv6 XFF, bad DSN, bad Redis URL, and IPv6 link-local with zone identifier.

**Already in place** (verified during review, no change needed): CORS origin URL parsing, TrustedProxies CIDR fail-fast, TLS cert/key Stat, secret redaction in `Redacted()`.