### PR TITLE
docs: add SECURITY.md, SSRF section, and initial ADRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,35 @@ HSTS is only emitted when the request arrives over TLS (direct or via a
 proxy that sets `X-Forwarded-Proto: https`), so plain-HTTP deployments
 behind a reverse proxy are not affected.
 
+## SSRF protection
+
+Every `target_url` submitted to `POST /api/v1/links` is normalised and
+rejected if the resolved hostname is anything other than a routable
+public address. The handler refuses, with HTTP 400, any URL whose host
+is:
+
+- a literal IP address inside the IANA private-use ranges
+  (RFC 1918: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`),
+  the loopback range (`127.0.0.0/8`, `::1`), link-local addresses
+  (`169.254.0.0/16`, `fe80::/10`), unique local IPv6 addresses
+  (`fc00::/7`), or the IANA shared address space / CGNAT block
+  (`100.64.0.0/10`);
+- the bare hostname `localhost` (case-insensitive) or an IPv6
+  link-local literal with a scope ID (`fe80::1%eth0`, bracketed
+  or unbracketed) — scope IDs are stripped before the link-local
+  range check fires; or
+- otherwise unparseable, missing a scheme, or using a scheme other than
+  `http`/`https`.
+
+DNS names other than `localhost` are **not** resolved at validation time:
+adding a per-request DNS lookup would both slow the create-link path and
+open the door to DNS rebinding (validate-time vs fetch-time mismatches).
+Operators concerned about hostname-based SSRF should pair this in-band
+check with outbound network policy at the pod / VM level.
+
+For full reporting instructions and the project threat model, see
+[SECURITY.md](SECURITY.md).
+
 ## API
 
 The full HTTP contract is described by an OpenAPI 3.0 document at

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,111 @@
+# Security policy
+
+## Supported versions
+
+Only the `main` branch and the most recently tagged release receive
+security fixes. There is no LTS line.
+
+| Version    | Supported          |
+| ---------- | ------------------ |
+| `main`     | :white_check_mark: |
+| latest tag | :white_check_mark: |
+| older tags | :x:                |
+
+## Reporting a vulnerability
+
+Please report security issues **privately** via GitHub's "Report a
+vulnerability" workflow on the repository's
+[Security tab](https://github.com/vancanhuit/url-shortener/security)
+(GitHub private vulnerability reporting). Do **not** open a public
+issue or pull request that describes the vulnerability.
+
+Include, where possible:
+
+- a clear description of the issue and the affected code path,
+- reproduction steps or a minimal proof of concept,
+- the commit SHA or release tag you tested against,
+- your assessment of the impact (confidentiality / integrity /
+  availability), and
+- any suggested remediation.
+
+You should receive an acknowledgement within a few business days.
+Coordinated disclosure timelines will be agreed on a per-report basis;
+the default working assumption is a fix-and-release window of 30–90
+days for non-trivial issues.
+
+## Scope
+
+The following are in scope for vulnerability reports:
+
+- the Go service in `cmd/url-shortener` and `internal/`,
+- the SQL migrations in `migrations/`,
+- the embedded Svelte SPA in `web/`,
+- the Docker image build (`Dockerfile`, `compose.yaml`),
+- the CI / release automation in `.github/`.
+
+The following are explicitly **out of scope**:
+
+- vulnerabilities in third-party services the binary connects to
+  (Postgres, Redis, your reverse proxy) — report those upstream;
+- denial-of-service via unbounded resource use by an authenticated
+  operator (e.g. setting `URL_SHORTENER_RATE_LIMIT_RPS=999999`);
+- physical access, social engineering, and supply-chain attacks
+  against dependencies (please report supply-chain CVEs to the
+  upstream maintainer first);
+- security weaknesses that require code modification of the
+  deployment (e.g. "if you set `Skip*` to true, the check is
+  bypassed") — that is by design.
+
+## Threat model summary
+
+`url-shortener` is a public-facing HTTP service that accepts redirect
+targets from anonymous callers and rewrites them to short codes. The
+primary security goals are:
+
+1. **Server-side request forgery (SSRF) containment.** The redirect
+   handler must not be weaponisable as a proxy to internal
+   infrastructure (cloud metadata services, Redis admin ports,
+   internal microservices). The validator rejects RFC 1918 / loopback
+   / link-local / ULA / CGNAT IP literals, bare `localhost`, and
+   IPv6 link-local literals with scope IDs at create-link time. See
+   the SSRF protection section in the README for the exact list.
+2. **Input-bound resource caps.** Request bodies are capped
+   (`URL_SHORTENER_MAX_REQUEST_BODY_BYTES`, default 16 KiB), the
+   per-IP create-link path can be rate-limited
+   (`URL_SHORTENER_RATE_LIMIT_RPS` + `_BURST`), and HTTP read /
+   write / idle timeouts are conservative by default. Long bodies,
+   slowloris-style clients, and request floods should fail closed.
+3. **Persistence safety.** All SQL is parameterised via sqlc-generated
+   code; no string concatenation reaches the driver. Migrations are
+   wrapped in an advisory lock to prevent concurrent runners from
+   interleaving DDL.
+4. **Operational secret hygiene.** `Config.Redacted()` substitutes
+   passwords in the URLs printed by `url-shortener config`; CI does
+   not echo secrets; the binary does not log raw connection strings.
+
+The following are **explicitly assumed handled upstream** (not by this
+service):
+
+- **Authentication / authorisation.** The HTTP API is open by design.
+  A reverse proxy or API gateway is expected to provide auth where
+  the deployment requires it.
+- **TLS termination.** Built-in TLS exists and is exercised by
+  integration tests, but production deployments typically terminate
+  TLS at a fronting proxy (Caddy / nginx / Traefik / a load balancer).
+- **Egress network policy.** SSRF containment is best-effort in-band.
+  Pair it with an egress allow-list at the pod / VM level for
+  defence in depth.
+
+## Known limitations
+
+- DNS names other than `localhost` are not resolved at validation
+  time. Adding per-request DNS would both slow the create-link path
+  and open the door to DNS rebinding. Operators that need
+  hostname-based SSRF protection must rely on egress network policy.
+- The in-memory rate limiter is per-instance. Horizontal scale-out
+  multiplies the effective per-IP budget by the replica count;
+  enforce a global budget at the fronting proxy / WAF for clusters
+  larger than a single replica.
+- Click-counter updates fire asynchronously after the redirect; a
+  hard process kill (SIGKILL) can drop in-flight increments.
+  Counts are best-effort, not audit-grade.

--- a/docs/adr/0001-chi-router.md
+++ b/docs/adr/0001-chi-router.md
@@ -1,0 +1,59 @@
+# ADR 0001: Use go-chi for HTTP routing
+
+- Status: Accepted
+- Date: 2025-11-15
+
+## Context
+
+The HTTP layer needs a router that:
+
+- supports `net/http` middleware composition (so we can keep
+  `slog`-based request logging, Prometheus RED metrics, security
+  headers, body-size caps, and CORS as standalone middlewares);
+- exposes the matched route pattern so RED metrics group by
+  template (`/r/{code}`) rather than by URL (`/r/abc123`,
+  `/r/def456`, …) and produce bounded label cardinality;
+- handles `*http.Request`/`http.Handler` types directly so it
+  composes with `oapi-codegen`'s strict-mode handlers and with
+  `httptest` in unit tests; and
+- has no runtime dependency on any framework-style "context"
+  type (request-scoped values stay in `context.Context`).
+
+The candidates considered were:
+
+- **`net/http.ServeMux` (Go 1.22+).** Method+path matching landed
+  in 1.22, but there is no way to recover the matched route
+  template from inside a middleware, which makes per-template
+  metrics impossible without per-route registration boilerplate.
+- **`labstack/echo`.** Framework-style: handlers take an
+  `echo.Context`, middlewares are echo-specific, and integrating
+  third-party `http.Handler` middleware requires adapter shims.
+- **`gin-gonic/gin`.** Same framework-style objection plus a
+  reflection-heavy binding system we do not need.
+- **`go-chi/chi`.** Idiomatic `http.Handler` + `http.HandlerFunc`,
+  middleware uses the stdlib signature, exposes the matched
+  pattern via `chi.RouteContext(ctx).RoutePattern()`.
+
+## Decision
+
+Use `github.com/go-chi/chi/v5` as the router for all HTTP routes
+mounted by `internal/server`. Continue to write middleware as plain
+`func(http.Handler) http.Handler`.
+
+## Consequences
+
+Positive:
+- Prometheus middleware can label metrics by `chi`'s route pattern.
+- Handler signatures stay stdlib-compatible, so `oapi-codegen`'s
+  strict-mode adapters and `httptest` work without shims.
+- Switching to a different router later is a localised change:
+  call sites are `r.Get`/`r.Post`/`r.Group`, not framework-specific.
+
+Negative:
+- `chi` is one more direct dependency. Mitigated by it being a
+  small, stable library with no transitive bloat.
+
+Neutral:
+- We do not use `chi`'s middleware-as-method pattern; everything
+  is plain `func(http.Handler) http.Handler` so swapping it is
+  mechanical.

--- a/docs/adr/0002-sqlc-for-data-access.md
+++ b/docs/adr/0002-sqlc-for-data-access.md
@@ -1,0 +1,68 @@
+# ADR 0002: Use sqlc for data-access code generation
+
+- Status: Accepted
+- Date: 2025-11-15
+
+## Context
+
+The service has a small, append-mostly schema (one `links` table)
+with a handful of query shapes: insert, lookup-by-code,
+lookup-by-target, list with pagination, increment click counter,
+soft delete, hard purge. The query set is unlikely to grow into
+the dozens.
+
+The data-access options considered were:
+
+- **Hand-written `database/sql` with prepared statements.**
+  Type-safe at the function-signature level, but the row-scan
+  boilerplate (`rows.Scan(&l.ID, &l.Code, &l.TargetURL, ...)`) is
+  easy to misalign with the schema and only fails at runtime.
+- **An ORM (`gorm`, `bun`, `ent`).** Solves the boilerplate but
+  takes ownership of the query language: ad-hoc Postgres features
+  we already use (partial unique indexes for dedup, `make_interval`
+  for purge windows, advisory locks for migrations) require either
+  raw-SQL escape hatches or upstream support. Schema migrations
+  are duplicated between the ORM model and the SQL files.
+- **`sqlc`.** Queries are written in plain SQL in
+  `internal/store/queries/`; `sqlc generate` produces typed Go
+  functions in `internal/store/db/`. The generator validates each
+  query against the live schema (driven from `migrations/`), so
+  a typo in a column name fails at code-gen time, not at runtime.
+
+## Decision
+
+Use [`sqlc`](https://sqlc.dev) as the source of truth for all
+query-shape Go code. Hand-write only the thin `Store` wrapper in
+`internal/store/postgres.go`, which:
+
+- adds the `DBTX` parameter so callers can pass either the pool or
+  a `pgx.Tx`,
+- maps generated `db.Link` rows to the public `store.Link`
+  pointer-time-fields shape,
+- and classifies pgx errors into the public `Err*` sentinels.
+
+Generated code lives at `internal/store/db/` and is committed to
+the repository (so consumers do not need `sqlc` installed to build).
+
+## Consequences
+
+Positive:
+- Adding or modifying a query is "edit `.sql` file, run
+  `sqlc generate`" — no manual Go updates, no risk of scan
+  argument drift.
+- Hand-written wrapper layer keeps public types decoupled from
+  generated ones; we can change pgx versions or even the SQL
+  driver without breaking handlers.
+
+Negative:
+- Generated code is in the repo, so PRs touching SQL include the
+  generated diff. Reviewers must remember to run `sqlc generate`
+  locally rather than hand-editing `internal/store/db/`.
+- One more developer tool (`sqlc`) in `mise.toml`.
+
+Neutral:
+- `sqlc` does not abstract the underlying driver, so we keep
+  using `pgx` directly for transactions, advisory locks, and
+  pool tuning. That matches the existing
+  [ADR 0001](0001-chi-router.md) philosophy of staying close to
+  the stdlib / driver surface.

--- a/docs/adr/0003-redis-redirect-cache.md
+++ b/docs/adr/0003-redis-redirect-cache.md
@@ -1,0 +1,78 @@
+# ADR 0003: Cache redirect lookups in Redis
+
+- Status: Accepted
+- Date: 2025-11-15
+
+## Context
+
+`GET /r/{code}` is the hot path of the service: every short link
+follower hits it, and the only work it has to do is read one row
+from `links` and issue a 302. Postgres can serve that load, but:
+
+- the read amplifies the connection-pool pressure for every other
+  query the service runs (create-link, list, soft-delete), and
+- when a code does not exist or is expired/deleted, we still pay a
+  full round-trip to learn that — and "not found" floods (scanners,
+  stale links, typos in QR codes) can be a meaningful share of
+  traffic.
+
+The options for shaving the read off the hot path were:
+
+- **In-process LRU only.** Zero network hop, but cache state is
+  per-replica: a redirect that was warmed on replica A is cold on
+  replica B, and revoking a link (soft delete) requires a custom
+  fan-out (or a process restart) to invalidate every replica.
+- **Postgres `LISTEN/NOTIFY` for in-process invalidation.**
+  Removes the fan-out problem above, but adds a long-lived
+  connection per replica and is awkward to plumb through `pgx`'s
+  pool.
+- **Redis as a shared cache.** One round-trip per lookup
+  regardless of replica, simple TTL semantics, and revocation is
+  just a `DEL` on the canonical key.
+
+We chose Redis primarily for the shared-state property and for the
+ease of negative caching (so "not found" replies don't repeatedly
+hit Postgres).
+
+## Decision
+
+Use Redis as a shared lookup cache for `GET /r/{code}`. Cache both
+positive answers (the resolved target URL) and negative answers
+(a sentinel value for not-found / gone), each with their own TTL:
+
+- `URL_SHORTENER_CACHE_TTL` (default 1 hour) for positives,
+- `URL_SHORTENER_NEGATIVE_CACHE_TTL` (default 30 seconds) for
+  negatives — short enough that a typo'd code becoming valid
+  after the operator creates it propagates quickly.
+
+Cache invalidation on soft-delete / hard-purge is the responsibility
+of the write-side handler: it issues a `DEL` after the SQL write
+commits. Redis is a hard dependency at startup (`config.Validate()`
+fails fast on an empty or malformed `URL_SHORTENER_REDIS_URL`); the
+service has no in-process fallback because the operational complexity
+of running with a partially-populated cache outweighs the convenience.
+
+## Consequences
+
+Positive:
+- Cold Postgres replica failovers do not cause a redirect-traffic
+  thundering herd: Redis still answers most lookups.
+- Negative caching absorbs `404`-spam (scanners, QR misreads, old
+  links) at single-digit-microsecond latency.
+- Cache is shared across replicas, so horizontal scale-out does
+  not divide the warm-cache benefit.
+
+Negative:
+- One more required dependency at deploy time.
+- Cache TTL upper-bounds how stale a revoked link can be served
+  on the read path between revocation and the next miss
+  (mitigated by the write-side `DEL`, but it is best-effort: a
+  failed `DEL` is logged, not retried).
+- A Redis outage takes the redirect path down with it (by design;
+  see the "no in-process fallback" note above). Treat it as the
+  same SLO tier as Postgres.
+
+Neutral:
+- The cache layer lives behind a small interface in
+  `internal/cache`, so replacing Redis with a different key/value
+  store later is a localised change.

--- a/docs/adr/0004-dedup-via-partial-unique-index.md
+++ b/docs/adr/0004-dedup-via-partial-unique-index.md
@@ -1,0 +1,89 @@
+# ADR 0004: Dedup auto-generated codes via a partial unique index
+
+- Status: Accepted
+- Date: 2025-11-15
+
+## Context
+
+When a caller submits `POST /api/v1/links` without a custom code,
+the service generates one. We want repeated submissions of the
+same `target_url` to converge on a single short code rather than
+mint a fresh one every time — otherwise the table grows linearly
+with traffic for trivially duplicated inputs (newsletter
+auto-fillers, monitoring probes, marketing redirects that get
+re-imported).
+
+The dedup approaches considered were:
+
+- **SELECT-then-INSERT (`if row exists return it else insert`).**
+  Vulnerable to a TOCTOU race: two concurrent callers both observe
+  no row, both insert, and one wins on a unique-violation while
+  the other silently creates a second row (or both create rows if
+  there is no unique index on `target_url`).
+- **Application-level mutex.** Solves the race within one process
+  but not across replicas, and serialises every create-link call
+  on a single goroutine.
+- **Advisory lock keyed on `hash(target_url)`.** Cross-replica
+  safe, but adds an extra round-trip per insert and ties dedup
+  correctness to lock-acquisition correctness.
+- **`INSERT ... ON CONFLICT DO UPDATE`** against a unique index on
+  `(target_url) WHERE expires_at IS NULL AND deleted_at IS NULL`.
+  Postgres serialises the contention at the index level; the
+  conflict path can `RETURNING` the existing row so callers always
+  get back the canonical code in one round-trip.
+
+The partial index is important: an expired or soft-deleted row
+for the same `target_url` must not block a fresh permanent insert.
+A full unique index on `target_url` would make resurrection of an
+old URL impossible without a hard delete first.
+
+## Decision
+
+- Add a partial unique index on `links(target_url)` covering only
+  auto-generated, live rows:
+  `WHERE auto_dedup = true AND expires_at IS NULL AND deleted_at IS NULL`.
+  Custom user-supplied codes set `auto_dedup = false` and therefore
+  do not participate in the dedup index, so two users picking the
+  same `target_url` with different custom codes both succeed.
+- Implement `CreateAutoLink` as a single
+  `INSERT ... ON CONFLICT (target_url) WHERE ... DO UPDATE SET code = links.code RETURNING *`.
+  The `DO UPDATE` is a deliberate no-op against `links.code` so that
+  `RETURNING` populates the row even on the conflict path (a plain
+  `DO NOTHING` would return zero rows for losers, forcing a second
+  `SELECT`).
+- Detect winner-vs-loser in Go by comparing the returned code
+  against the candidate code the caller supplied: equal means we
+  inserted (winner), different means we collided onto an
+  existing row (loser).
+- Cover the race with an integration test that spawns several
+  goroutines concurrently calling `CreateAutoLink` on the same
+  target and asserts exactly one winner.
+
+## Consequences
+
+Positive:
+- Atomic: no application-level locking, no second round-trip,
+  no risk of a missed race.
+- Cross-replica safe by construction (Postgres serialises the
+  conflict).
+- Expired / soft-deleted rows do not block resurrection of the
+  same URL as a fresh permanent link.
+
+Negative:
+- The "code returned == code I proposed" winner test is a subtle
+  invariant: it relies on candidate codes being unique-per-call.
+  The code generator collision-rate is low enough that this holds
+  in practice; the integration test pins the behaviour.
+- The `DO UPDATE SET code = links.code` no-op is a Postgres-specific
+  idiom (chosen so `RETURNING` populates on the conflict path).
+  Reviewers occasionally flag the no-op as redundant. It is not —
+  removing it forces a second `SELECT` for losers.
+
+Neutral:
+- Custom (user-supplied) codes go through `CreateLink` with
+  `auto_dedup = false`, which uses the unique index on `code` and
+  surfaces `ErrCodeTaken` on conflict rather than dedupe-merging.
+  Auto-generated and user-specified codes intentionally have
+  different "what happens on conflict" semantics; the
+  `auto_dedup` flag is what keeps the two paths from
+  interfering through the shared `target_url` index.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,36 @@
+# Architecture decision records
+
+This directory captures the rationale behind architectural decisions
+that would otherwise have to be re-derived from the codebase. Each ADR
+is immutable: once a decision is accepted, the file is not edited; a
+later decision that supersedes it is recorded as a new ADR that links
+back.
+
+## Format
+
+We use a lightweight Michael Nygard–style template:
+
+```
+# ADR NNNN: <title>
+
+- Status: <Proposed | Accepted | Superseded by ADR-XXXX>
+- Date: YYYY-MM-DD
+
+## Context
+<the forces at play>
+
+## Decision
+<the choice we made>
+
+## Consequences
+<positive, negative, neutral fallout>
+```
+
+## Index
+
+| ADR | Title | Status |
+| --- | ----- | ------ |
+| [0001](0001-chi-router.md) | Use go-chi for HTTP routing | Accepted |
+| [0002](0002-sqlc-for-data-access.md) | Use sqlc for data-access code generation | Accepted |
+| [0003](0003-redis-redirect-cache.md) | Cache redirect lookups in Redis | Accepted |
+| [0004](0004-dedup-via-partial-unique-index.md) | Dedup auto-generated codes via a partial unique index | Accepted |


### PR DESCRIPTION
## Summary

Phase D of the codebase review (P2 items 11, 12, 16). Documentation-only; no code or test changes. Independent of #134 (Phase B) and #135 (Phase C).

### SECURITY.md (item 11)

A new top-level \`SECURITY.md\` covering:

- supported versions (\`main\` + most recent tag),
- private reporting workflow via GitHub's vulnerability reporting tab,
- in-scope code paths and explicitly-out-of-scope reports (upstream-dependency CVEs, DoS via authenticated-operator config, etc.),
- a threat-model summary covering SSRF containment, input-bound resource caps (body size, rate limiting, HTTP timeouts), persistence safety (sqlc-parameterised SQL + advisory-locked migrations), and secret hygiene,
- known limitations (no DNS resolution at validation time, per-instance rate limit, best-effort click counters).

### README SSRF section (item 12)

A new \`## SSRF protection\` section between \`## Security headers\` and \`## API\` enumerating the exact ranges and patterns rejected by \`isPrivateHost\` (RFC 1918, loopback, IPv4/IPv6 link-local, IPv6 ULA, CGNAT, bare \`localhost\`, IPv6 scope IDs) and explaining why DNS resolution is deliberately not part of the in-band check (latency + DNS rebinding) plus the recommendation to pair this with egress network policy.

### Initial ADRs (item 16)

New \`docs/adr/\` directory with a Nygard-style template and four initial records:

- **ADR 0001** — Use go-chi for HTTP routing (alternative middleware/router options evaluated; cited the \`chi.RoutePattern\` requirement for bounded-cardinality Prometheus labels).
- **ADR 0002** — Use sqlc for data-access code generation (compared with hand-written \`database/sql\` and ORM approaches; documented the generated-code-in-repo convention).
- **ADR 0003** — Cache redirect lookups in Redis (compared in-process LRU, \`LISTEN/NOTIFY\`, and Redis; documented positive + negative TTLs and the deliberate hard-dependency posture).
- **ADR 0004** — Dedup auto-generated codes via a partial unique index (documented the actual implementation: partial index gated on \`auto_dedup = true\`, \`DO UPDATE SET code = links.code\` no-op so \`RETURNING\` populates on conflict, and the \"returned code == proposed code\" winner-detection idiom in the Go wrapper).

No code, tests, or CI configuration are touched. \`mise run lint\` was not re-run because the diff is markdown-only.

## After this PR

This completes the four-phase codebase-review execution plan (#133 Phase A merged; #134 Phase B and #135 Phase C still open).