### PR TITLE
feat(config): enforce TLS and explicit pool ceiling in prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,11 @@ local `compose.yaml` overrides them for development.
 | `URL_SHORTENER_BASE_URL`       | `http://localhost:8080`       | Public origin used when building short-link URLs.   |
 | `URL_SHORTENER_LOG_LEVEL`      | `info`                        | One of `debug`, `info`, `warn`, `error`.            |
 | `URL_SHORTENER_LOG_FORMAT`     | `text` in dev, `json` in prod | `text` (human-readable) or `json` (structured).     |
-| `URL_SHORTENER_DATABASE_URL`   | _(empty)_                     | **Required.** Postgres connection string. Redacted when printed. |
+| `URL_SHORTENER_DATABASE_URL`   | _(empty)_                     | **Required.** Postgres connection string. Redacted when printed. In `prod` the DSN must enforce TLS (`sslmode=require`, `verify-ca`, or `verify-full`); `disable`/`prefer`/`allow` are rejected at startup. |
 | `URL_SHORTENER_REDIS_URL`      | _(empty)_                     | **Required.** Redis connection string. Redacted when printed.   |
 | `URL_SHORTENER_AUTO_MIGRATE`   | `true`                        | When `true` (the default), `run` applies any pending migrations before serving. A Postgres advisory lock serializes concurrent startup across replicas. Set to `false` to run `migrate up` as an explicit, separately-audited step. |
 | `URL_SHORTENER_CODE_LENGTH`    | `7`                           | Length of auto-generated short codes (base62). Must be in [4, 64]. |
-| `URL_SHORTENER_DB_MAX_CONNS`           | _(pgx default: max(4, NumCPU))_ | Upper bound on simultaneous Postgres connections. Set above the default to absorb burst load without queueing requests on the pool. |
+| `URL_SHORTENER_DB_MAX_CONNS`           | _(pgx default: max(4, NumCPU))_ | Upper bound on simultaneous Postgres connections. Set above the default to absorb burst load without queueing requests on the pool. **Required (> 0) in `prod`** so the pool ceiling is a deliberate decision rather than pgx's small default. |
 | `URL_SHORTENER_DB_MIN_CONNS`           | _(pgx default: 0)_              | Idle connections kept warm. Useful to amortize TLS/handshake cost on bursty workloads. |
 | `URL_SHORTENER_DB_MAX_CONN_LIFETIME`   | _(pgx default: 1h)_             | Hard cap on a connection's age. Forces rotation through floating-IP failovers and clears DB-side connection-state drift. Accepts Go duration syntax (e.g. `30m`, `2h`). |
 | `URL_SHORTENER_DB_MAX_CONN_IDLE_TIME`  | _(pgx default: 30m)_            | How long a connection may sit unused before being closed. |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -201,7 +201,8 @@ func (c Config) Validate() error {
 	// Parse the DSN now so a typo (missing scheme, bad port, unbalanced
 	// quote) surfaces as a clear validation error instead of as the first
 	// pool-acquire attempt failing with a less obvious message.
-	if _, err := pgx.ParseConfig(c.DatabaseURL); err != nil {
+	pgConf, err := pgx.ParseConfig(c.DatabaseURL)
+	if err != nil {
 		return fmt.Errorf("config: database_url: %w", err)
 	}
 	// Redis is a required runtime dependency: the cache is on the hot path
@@ -235,6 +236,24 @@ func (c Config) Validate() error {
 	}
 	if c.DBHealthCheckPeriod < 0 {
 		return fmt.Errorf("config: db_health_check_period must be >= 0")
+	}
+
+	// Production hardening. These configurations are valid in dev but are
+	// almost always mistakes in prod, where they are expensive to notice:
+	//
+	//   - A non-TLS Postgres connection ships credentials and link data in
+	//     cleartext. Require sslmode require/verify-ca/verify-full.
+	//   - An unbounded pool (db_max_conns left at pgx's small default, or 0)
+	//     lets a traffic burst exhaust the database's connection slots.
+	//     Force an explicit ceiling so capacity is a deliberate decision.
+	if c.Env == EnvProd {
+		if !dsnEnforcesTLS(pgConf) {
+			return fmt.Errorf("config: database_url must enforce TLS in prod " +
+				"(set sslmode=require, verify-ca, or verify-full)")
+		}
+		if c.DBMaxConns <= 0 {
+			return fmt.Errorf("config: db_max_conns must be set explicitly (> 0) in prod")
+		}
 	}
 
 	// Rate-limit knobs: both must be non-negative. RateLimitBurst
@@ -303,6 +322,28 @@ func (c Config) Validate() error {
 	}
 
 	return nil
+}
+
+// dsnEnforcesTLS reports whether a parsed Postgres DSN mandates TLS for
+// every connection attempt. pgx models sslmode in two places:
+//
+//   - The primary Config.TLSConfig is nil only for sslmode=disable.
+//   - sslmode=prefer/allow (which silently downgrade to cleartext) are
+//     implemented as Fallbacks with a nil TLSConfig.
+//
+// So TLS is genuinely enforced only when the primary has a TLSConfig and
+// no fallback offers a plaintext path. require, verify-ca, and verify-full
+// all satisfy this; disable, prefer, and allow do not.
+func dsnEnforcesTLS(cfg *pgx.ConnConfig) bool {
+	if cfg.TLSConfig == nil {
+		return false
+	}
+	for _, fb := range cfg.Fallbacks {
+		if fb.TLSConfig == nil {
+			return false
+		}
+	}
+	return true
 }
 
 // Redacted returns a copy of c with passwords stripped from URL-shaped

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,9 +14,11 @@ import (
 func TestLoad_Defaults(t *testing.T) {
 	clearEnv(t)
 	// Postgres + Redis are required fields; set the minimum needed for
-	// Load() to succeed.
-	t.Setenv("URL_SHORTENER_DATABASE_URL", "postgres://u:p@h:5432/db")
+	// Load() to succeed. The default env is prod, which additionally
+	// requires a TLS-enforcing DSN and an explicit pool ceiling.
+	t.Setenv("URL_SHORTENER_DATABASE_URL", "postgres://u:p@h:5432/db?sslmode=require")
 	t.Setenv("URL_SHORTENER_REDIS_URL", "redis://localhost:6379/0")
+	t.Setenv("URL_SHORTENER_DB_MAX_CONNS", "10")
 
 	cfg, err := config.Load()
 	if err != nil {
@@ -90,7 +92,8 @@ func TestLoad_EnvOverrides(t *testing.T) {
 
 func TestLoad_DBPoolEnvOverrides(t *testing.T) {
 	clearEnv(t)
-	t.Setenv("URL_SHORTENER_DATABASE_URL", "postgres://u:p@h:5432/db")
+	// Default env is prod, so the DSN must enforce TLS.
+	t.Setenv("URL_SHORTENER_DATABASE_URL", "postgres://u:p@h:5432/db?sslmode=require")
 	t.Setenv("URL_SHORTENER_REDIS_URL", "redis://localhost:6379/0")
 	t.Setenv("URL_SHORTENER_DB_MAX_CONNS", "32")
 	t.Setenv("URL_SHORTENER_DB_MIN_CONNS", "4")
@@ -125,13 +128,14 @@ func TestValidate_RejectsBadDBPoolValues(t *testing.T) {
 
 	const (
 		redisURL    = "redis://localhost:6379/0"
-		databaseURL = "postgres://u:p@h:5432/db"
+		databaseURL = "postgres://u:p@h:5432/db?sslmode=require"
 	)
 	base := func() config.Config {
 		return config.Config{
 			Env: "prod", Addr: ":8080", BaseURL: "x",
 			LogLevel: "info", LogFormat: "json",
 			DatabaseURL: databaseURL, RedisURL: redisURL,
+			DBMaxConns: 10,
 		}
 	}
 
@@ -165,6 +169,77 @@ func TestValidate_RejectsBadDBPoolValues(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestValidate_ProdHardening covers the prod-only guards: the Postgres
+// DSN must enforce TLS, and db_max_conns must be set explicitly. Dev is
+// exempt from both so the local compose stack (sslmode=disable, default
+// pool) keeps working.
+func TestValidate_ProdHardening(t *testing.T) {
+	t.Parallel()
+
+	const redisURL = "redis://localhost:6379/0"
+	base := func(env, dsn string, maxConns int32) config.Config {
+		return config.Config{
+			Env: env, Addr: ":8080", BaseURL: "http://x",
+			LogLevel: "info", LogFormat: "json",
+			DatabaseURL: dsn, RedisURL: redisURL,
+			DBMaxConns: maxConns,
+		}
+	}
+
+	t.Run("prod with require + max_conns is valid", func(t *testing.T) {
+		t.Parallel()
+		c := base("prod", "postgres://u:p@h:5432/db?sslmode=require", 10)
+		if err := c.Validate(); err != nil {
+			t.Errorf("Validate() = %v, want nil", err)
+		}
+	})
+
+	for _, mode := range []string{"verify-ca", "verify-full"} {
+		t.Run("prod accepts sslmode="+mode, func(t *testing.T) {
+			t.Parallel()
+			c := base("prod", "postgres://u:p@h:5432/db?sslmode="+mode, 10)
+			if err := c.Validate(); err != nil {
+				t.Errorf("Validate() = %v, want nil", err)
+			}
+		})
+	}
+
+	for _, mode := range []string{"disable", "prefer", "allow"} {
+		t.Run("prod rejects sslmode="+mode, func(t *testing.T) {
+			t.Parallel()
+			c := base("prod", "postgres://u:p@h:5432/db?sslmode="+mode, 10)
+			if err := c.Validate(); err == nil {
+				t.Errorf("Validate() = nil; want TLS-enforcement error for sslmode=%s", mode)
+			}
+		})
+	}
+
+	t.Run("prod rejects DSN without sslmode (defaults to prefer)", func(t *testing.T) {
+		t.Parallel()
+		c := base("prod", "postgres://u:p@h:5432/db", 10)
+		if err := c.Validate(); err == nil {
+			t.Error("Validate() = nil; want TLS-enforcement error for implicit sslmode=prefer")
+		}
+	})
+
+	t.Run("prod requires explicit db_max_conns", func(t *testing.T) {
+		t.Parallel()
+		c := base("prod", "postgres://u:p@h:5432/db?sslmode=require", 0)
+		if err := c.Validate(); err == nil {
+			t.Error("Validate() = nil; want error for unset db_max_conns in prod")
+		}
+	})
+
+	t.Run("dev is exempt from both guards", func(t *testing.T) {
+		t.Parallel()
+		c := base("dev", "postgres://u:p@h:5432/db?sslmode=disable", 0)
+		c.LogFormat = "text"
+		if err := c.Validate(); err != nil {
+			t.Errorf("Validate() = %v, want nil for dev", err)
+		}
+	})
 }
 
 func TestValidate_RejectsBadValues(t *testing.T) {
@@ -222,8 +297,11 @@ func TestRedacted_StripsPasswords(t *testing.T) {
 
 func TestLoad_TLSAndTrustedProxiesEnvOverrides(t *testing.T) {
 	clearEnv(t)
-	t.Setenv("URL_SHORTENER_DATABASE_URL", "postgres://u:p@h:5432/db")
+	// Default env is prod: the DSN must enforce TLS and the pool ceiling
+	// must be explicit.
+	t.Setenv("URL_SHORTENER_DATABASE_URL", "postgres://u:p@h:5432/db?sslmode=require")
 	t.Setenv("URL_SHORTENER_REDIS_URL", "redis://localhost:6379/0")
+	t.Setenv("URL_SHORTENER_DB_MAX_CONNS", "10")
 	// Files must exist for Validate's stat check to pass; create
 	// scratch files with arbitrary content (Validate doesn't try to
 	// parse the PEM, only Stat the path).
@@ -264,7 +342,7 @@ func TestValidate_TLSAndTrustedProxies(t *testing.T) {
 
 	const (
 		redisURL    = "redis://localhost:6379/0"
-		databaseURL = "postgres://u:p@h:5432/db"
+		databaseURL = "postgres://u:p@h:5432/db?sslmode=require"
 	)
 	// realDir + realCert/realKey are paths that exist, used by the
 	// happy-path subtests. Each subtest gets its own t.TempDir to
@@ -284,6 +362,7 @@ func TestValidate_TLSAndTrustedProxies(t *testing.T) {
 			Env: "prod", Addr: ":8080", BaseURL: "http://x",
 			LogLevel: "info", LogFormat: "json",
 			DatabaseURL: databaseURL, RedisURL: redisURL,
+			DBMaxConns: 10,
 		}, certPath, keyPath
 	}
 
@@ -381,6 +460,7 @@ func clearEnv(t *testing.T) {
 
 func TestLoad_CacheTTLEnvOverrides(t *testing.T) {
 	clearEnv(t)
+	t.Setenv("URL_SHORTENER_ENV", "dev")
 	t.Setenv("URL_SHORTENER_DATABASE_URL", "postgres://u:p@h:5432/db")
 	t.Setenv("URL_SHORTENER_REDIS_URL", "redis://localhost:6379/0")
 	t.Setenv("URL_SHORTENER_CACHE_TTL", "2h")
@@ -400,6 +480,7 @@ func TestLoad_CacheTTLEnvOverrides(t *testing.T) {
 
 func TestLoad_CacheTTLDefaultsToZero(t *testing.T) {
 	clearEnv(t)
+	t.Setenv("URL_SHORTENER_ENV", "dev")
 	t.Setenv("URL_SHORTENER_DATABASE_URL", "postgres://u:p@h:5432/db")
 	t.Setenv("URL_SHORTENER_REDIS_URL", "redis://localhost:6379/0")
 


### PR DESCRIPTION
## Summary
Adds two prod-only configuration guards in `Config.Validate()`:

1. **TLS-enforcing Postgres DSN.** In `prod`, the DSN must use `sslmode=require`, `verify-ca`, or `verify-full`. `disable`, `prefer`, and `allow` (which silently downgrade to cleartext) are rejected at startup.
2. **Explicit `db_max_conns`.** In `prod`, `URL_SHORTENER_DB_MAX_CONNS` must be `> 0` so a traffic burst can't exhaust the database's connection slots via pgx's small default.

## How TLS enforcement is detected
pgx models `sslmode` in the parsed config: the primary `TLSConfig` is nil only for `disable`, and `prefer`/`allow` are implemented as `Fallbacks` with a nil `TLSConfig`. The new `dsnEnforcesTLS` helper requires a non-nil primary `TLSConfig` and no plaintext fallback — so only `require`/`verify-ca`/`verify-full` pass.

## Impact
- **Dev is exempt** from both guards, so the local compose stack (`sslmode=disable`, default pool) is unaffected.
- Existing prod deployments must ensure their DSN enforces TLS and `DB_MAX_CONNS` is set. README updated.

## Tests
- New `TestValidate_ProdHardening` covers the accept (require/verify-ca/verify-full + max_conns) and reject (disable/prefer/allow, missing max_conns) matrix, plus dev exemption.
- Updated existing prod-env config fixtures to be prod-valid.
- Full `go test ./...` and `mise run lint` green.