### PR TITLE
feat(metrics): add business and pgxpool Prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,19 +376,40 @@ Static assets are served from the embedded `web/dist/` filesystem:
 
 ## Operational endpoints
 
-The HTTP server exposes three operational endpoints:
+The HTTP server exposes these operational endpoints:
 
 | Endpoint    | Purpose                          | Behaviour                                                                                     |
 | ----------- | -------------------------------- | --------------------------------------------------------------------------------------------- |
 | `/livez`   | Liveness probe                   | Always returns `200` + `{"status":"ok"}` while the process is responsive. No dependencies.    |
 | `/readyz`   | Readiness probe                  | Pings every registered dependency. Returns `200` when all are healthy, `503` otherwise.       |
 | `/version`  | Build metadata                   | Returns `{"version":"...","commit":"...","date":"..."}` baked into the binary at build time.  |
+| `/metrics`  | Prometheus exposition            | RED, Go runtime, Postgres pool, and business counters in the Prometheus text format.          |
 
 `/readyz` pings Postgres and Redis -- both are mandatory runtime
 dependencies (`config.Validate` rejects an empty
 `URL_SHORTENER_DATABASE_URL` or `URL_SHORTENER_REDIS_URL` at startup).
 Each check has its own line in the JSON body so operators can see
 which dependency is unhappy.
+
+### Metrics
+
+`/metrics` exposes, on a single Prometheus registry:
+
+- **RED** &mdash; `http_requests_total{method,route,status_code}` and
+  `http_request_duration_seconds{method,route}` for every request.
+- **Runtime** &mdash; the standard Go and process collectors.
+- **Postgres pool** (`pgxpool_*`) &mdash; point-in-time gauges
+  (`acquired_conns`, `idle_conns`, `total_conns`, `max_conns`, ...) and
+  lifetime counters (`acquire_total`, `empty_acquire_total`,
+  `canceled_acquire_total`, `max_lifetime_destroy_total`, ...). Alert on
+  sustained `acquired_conns` ≈ `max_conns` (saturation) and rising
+  `empty_acquire_total` (contention).
+- **Business** &mdash; `links_shortened_total{outcome}`
+  (`created`/`deduped`), `links_redirects_total{outcome}`
+  (`cache_hit`/`negative_hit`/`store_hit`/`not_found`/`gone`/`error`),
+  `links_code_collisions_total`, and `links_rate_limited_total`. Known
+  label series are pre-initialized to `0` so dashboards have no gaps
+  before the first occurrence.
 
 ## Deployment
 

--- a/internal/handlers/links.go
+++ b/internal/handlers/links.go
@@ -122,6 +122,7 @@ type Links struct {
 	gen         Generator
 	baseURL     string
 	logger      *slog.Logger
+	metrics     Metrics
 	cacheTTL    time.Duration
 	negCacheTTL time.Duration
 
@@ -144,6 +145,7 @@ type LinksConfig struct {
 	Generator        Generator
 	BaseURL          string
 	Logger           *slog.Logger
+	Metrics          Metrics
 	CacheTTL         time.Duration
 	NegativeCacheTTL time.Duration
 }
@@ -162,12 +164,17 @@ func NewLinks(cfg LinksConfig) *Links {
 	if negCacheTTL <= 0 {
 		negCacheTTL = NegativeCacheTTL
 	}
+	metrics := cfg.Metrics
+	if metrics == nil {
+		metrics = noopMetrics{}
+	}
 	return &Links{
 		store:       cfg.Store,
 		cache:       cfg.Cache,
 		gen:         cfg.Generator,
 		baseURL:     strings.TrimRight(cfg.BaseURL, "/"),
 		logger:      logger,
+		metrics:     metrics,
 		cacheTTL:    cacheTTL,
 		negCacheTTL: negCacheTTL,
 	}

--- a/internal/handlers/links_handlers.go
+++ b/internal/handlers/links_handlers.go
@@ -38,8 +38,10 @@ func (h *Links) CreateLink(ctx context.Context, req api.CreateLinkRequestObject)
 	}
 	resp := h.makeResp(link)
 	if created {
+		h.metrics.IncShorten(ShortenCreated)
 		return api.CreateLink201JSONResponse(resp), nil
 	}
+	h.metrics.IncShorten(ShortenDeduped)
 	return api.CreateLink200JSONResponse(resp), nil
 }
 
@@ -121,6 +123,7 @@ func (h *Links) DeleteLink(ctx context.Context, req api.DeleteLinkRequestObject)
 func (h *Links) Redirect(w http.ResponseWriter, r *http.Request) {
 	code := chi.URLParam(r, "code")
 	if !shortener.ValidCode(code) {
+		h.metrics.IncRedirect(RedirectNotFound)
 		writeJSON(w, http.StatusNotFound, errResp(api.ErrorResponseCodeNotFound, "not found"))
 		return
 	}
@@ -128,10 +131,12 @@ func (h *Links) Redirect(w http.ResponseWriter, r *http.Request) {
 
 	target, hit, negative := h.cacheGet(ctx, code)
 	if hit && negative {
+		h.metrics.IncRedirect(RedirectNegativeHit)
 		writeJSON(w, http.StatusNotFound, errResp(api.ErrorResponseCodeNotFound, "not found"))
 		return
 	}
 	if hit {
+		h.metrics.IncRedirect(RedirectCacheHit)
 		h.recordClick(code)                           //nolint:contextcheck // goroutine outlives the request; uses its own timeout context
 		http.Redirect(w, r, target, http.StatusFound) //nolint:gosec // target is populated exclusively from DB-validated URLs (http/https, non-private hosts); the cache is internal, not user-controlled
 		return
@@ -140,26 +145,31 @@ func (h *Links) Redirect(w http.ResponseWriter, r *http.Request) {
 	link, err := h.store.GetLinkByCode(ctx, nil, code)
 	if errors.Is(err, store.ErrNotFound) {
 		h.cachePutNegative(ctx, code)
+		h.metrics.IncRedirect(RedirectNotFound)
 		writeJSON(w, http.StatusNotFound, errResp(api.ErrorResponseCodeNotFound, "not found"))
 		return
 	}
 	if err != nil {
 		h.logger.Error("links: redirect lookup failed", "error", err, "code", code)
+		h.metrics.IncRedirect(RedirectError)
 		writeJSON(w, http.StatusInternalServerError, errResp(api.ErrorResponseCodeInternalError, "internal error"))
 		return
 	}
 	if link.IsDeleted() {
 		h.cachePutNegative(ctx, code)
+		h.metrics.IncRedirect(RedirectGone)
 		writeJSON(w, http.StatusGone, errResp(api.ErrorResponseCodeLinkDeleted, "link has been deleted"))
 		return
 	}
 	if link.IsExpired() {
 		h.cachePutNegative(ctx, code)
+		h.metrics.IncRedirect(RedirectGone)
 		writeJSON(w, http.StatusGone, errResp(api.ErrorResponseCodeLinkExpired, "link has expired"))
 		return
 	}
 
 	h.cachePut(ctx, link)
+	h.metrics.IncRedirect(RedirectStoreHit)
 	h.recordClick(link.Code) //nolint:contextcheck // goroutine outlives the request; uses its own timeout context
 	http.Redirect(w, r, link.TargetURL, http.StatusFound)
 }

--- a/internal/handlers/links_service.go
+++ b/internal/handlers/links_service.go
@@ -154,6 +154,7 @@ func (h *Links) createOrReuseAutoLink(ctx context.Context, target string) (store
 		}
 		link, created, err := h.store.CreateAutoLink(ctx, nil, code, target)
 		if errors.Is(err, store.ErrCodeTaken) {
+			h.metrics.IncCodeCollision()
 			h.logger.Warn("links: code collision; retrying", "attempt", i+1, "code", code)
 			continue
 		}
@@ -177,6 +178,7 @@ func (h *Links) createWithRandomCode(ctx context.Context, target string, expires
 		}
 		l, err := h.store.CreateLink(ctx, nil, code, target, expiresAt)
 		if errors.Is(err, store.ErrCodeTaken) {
+			h.metrics.IncCodeCollision()
 			h.logger.Warn("links: code collision; retrying", "attempt", i+1, "code", code)
 			continue
 		}

--- a/internal/handlers/metrics.go
+++ b/internal/handlers/metrics.go
@@ -1,0 +1,60 @@
+package handlers
+
+// Metrics records business-level counters for the links handler: how many
+// links are shortened (and whether they were freshly created or served
+// from the dedup path), how redirects resolve, and how often the
+// auto-generated-code loop collides.
+//
+// It is deliberately a small interface rather than a direct Prometheus
+// dependency so the handlers package stays free of metrics-library imports
+// and tests can run against the no-op default. Every method must be safe
+// for concurrent use; the server wires a Prometheus-backed implementation.
+type Metrics interface {
+	// IncShorten records a successful create. outcome distinguishes a
+	// freshly inserted row from one reused via the dedup path.
+	IncShorten(outcome ShortenOutcome)
+	// IncRedirect records how a /r/{code} lookup resolved.
+	IncRedirect(outcome RedirectOutcome)
+	// IncCodeCollision records one auto-generated-code collision (a
+	// retry inside the create loop). A nonzero rate is normal as the
+	// keyspace fills; a spike signals an undersized code length.
+	IncCodeCollision()
+}
+
+// ShortenOutcome labels a successful shorten by how the row was obtained.
+type ShortenOutcome string
+
+const (
+	// ShortenCreated is a brand-new row inserted for this request.
+	ShortenCreated ShortenOutcome = "created"
+	// ShortenDeduped is an existing permanent row reused for the same
+	// normalized target (auto-generated, non-expiring requests only).
+	ShortenDeduped ShortenOutcome = "deduped"
+)
+
+// RedirectOutcome labels how a redirect lookup terminated.
+type RedirectOutcome string
+
+const (
+	// RedirectCacheHit served a 302 straight from a positive cache entry.
+	RedirectCacheHit RedirectOutcome = "cache_hit"
+	// RedirectNegativeHit short-circuited on a negative cache entry (404).
+	RedirectNegativeHit RedirectOutcome = "negative_hit"
+	// RedirectStoreHit resolved from the store after a cache miss (302).
+	RedirectStoreHit RedirectOutcome = "store_hit"
+	// RedirectNotFound found no live row (404).
+	RedirectNotFound RedirectOutcome = "not_found"
+	// RedirectGone matched a soft-deleted or expired row (410).
+	RedirectGone RedirectOutcome = "gone"
+	// RedirectError aborted on an internal lookup error (500).
+	RedirectError RedirectOutcome = "error"
+)
+
+// noopMetrics is the default Metrics implementation: it discards every
+// observation. Used when the handler is constructed without an explicit
+// Metrics (all current tests, and any embedding that doesn't care).
+type noopMetrics struct{}
+
+func (noopMetrics) IncShorten(ShortenOutcome)   {}
+func (noopMetrics) IncRedirect(RedirectOutcome) {}
+func (noopMetrics) IncCodeCollision()           {}

--- a/internal/handlers/metrics_test.go
+++ b/internal/handlers/metrics_test.go
@@ -1,0 +1,193 @@
+package handlers_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/vancanhuit/url-shortener/internal/handlers"
+)
+
+// fakeMetrics is a concurrency-safe handlers.Metrics that records every
+// observation so tests can assert the handler emits the right outcome.
+type fakeMetrics struct {
+	mu         sync.Mutex
+	shorten    map[handlers.ShortenOutcome]int
+	redirect   map[handlers.RedirectOutcome]int
+	collisions int
+}
+
+func newFakeMetrics() *fakeMetrics {
+	return &fakeMetrics{
+		shorten:  map[handlers.ShortenOutcome]int{},
+		redirect: map[handlers.RedirectOutcome]int{},
+	}
+}
+
+func (f *fakeMetrics) IncShorten(o handlers.ShortenOutcome) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.shorten[o]++
+}
+
+func (f *fakeMetrics) IncRedirect(o handlers.RedirectOutcome) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.redirect[o]++
+}
+
+func (f *fakeMetrics) IncCodeCollision() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.collisions++
+}
+
+func (f *fakeMetrics) shortenCount(o handlers.ShortenOutcome) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.shorten[o]
+}
+
+func (f *fakeMetrics) redirectCount(o handlers.RedirectOutcome) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.redirect[o]
+}
+
+func newHandlerWithMetrics(
+	t *testing.T,
+	st handlers.LinkStore,
+	cc handlers.LinkCache,
+	gen handlers.Generator,
+	m handlers.Metrics,
+) chi.Router {
+	t.Helper()
+	h := handlers.NewLinks(handlers.LinksConfig{
+		Store:     st,
+		Cache:     cc,
+		Generator: gen,
+		BaseURL:   baseURL,
+		Metrics:   m,
+	})
+	r := chi.NewRouter()
+	h.Mount(r)
+	return r
+}
+
+// TestMetrics_ShortenCreated: a fresh create increments the "created"
+// shorten counter.
+func TestMetrics_ShortenCreated(t *testing.T) {
+	t.Parallel()
+	st, cc := newFakeStore(), newFakeCache()
+	m := newFakeMetrics()
+	e := newHandlerWithMetrics(t, st, cc, &scriptedGen{codes: []string{"abc1234"}}, m)
+
+	rec, body := doJSON(t, e, http.MethodPost, "/api/v1/links", `{"target_url":"https://example.com"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", rec.Code, string(body))
+	}
+	if got := m.shortenCount(handlers.ShortenCreated); got != 1 {
+		t.Errorf("ShortenCreated = %d, want 1", got)
+	}
+}
+
+// TestMetrics_ShortenDeduped: a second auto-generated create for the
+// same target reuses the row and increments the "deduped" counter.
+func TestMetrics_ShortenDeduped(t *testing.T) {
+	t.Parallel()
+	st, cc := newFakeStore(), newFakeCache()
+	m := newFakeMetrics()
+	e := newHandlerWithMetrics(t, st, cc, &scriptedGen{codes: []string{"first00", "second0"}}, m)
+
+	const reqBody = `{"target_url":"https://dedup.example"}`
+	if rec, body := doJSON(t, e, http.MethodPost, "/api/v1/links", reqBody); rec.Code != http.StatusCreated {
+		t.Fatalf("first create status = %d, body = %s", rec.Code, string(body))
+	}
+	rec, body := doJSON(t, e, http.MethodPost, "/api/v1/links", reqBody)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second create status = %d, body = %s (want 200 dedup)", rec.Code, string(body))
+	}
+	if got := m.shortenCount(handlers.ShortenCreated); got != 1 {
+		t.Errorf("ShortenCreated = %d, want 1", got)
+	}
+	if got := m.shortenCount(handlers.ShortenDeduped); got != 1 {
+		t.Errorf("ShortenDeduped = %d, want 1", got)
+	}
+}
+
+// TestMetrics_RedirectStoreHitThenCacheHit: the first redirect resolves
+// from the store, the second from the cache, each recording its outcome.
+func TestMetrics_RedirectStoreHitThenCacheHit(t *testing.T) {
+	t.Parallel()
+	st, cc := newFakeStore(), newFakeCache()
+	if _, err := st.CreateLink(context.Background(), nil, "live123", "https://example.com", nil); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	m := newFakeMetrics()
+	e := newHandlerWithMetrics(t, st, cc, &scriptedGen{}, m)
+
+	do := func() int {
+		req := httptest.NewRequest(http.MethodGet, "/r/live123", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		return rec.Code
+	}
+	if c := do(); c != http.StatusFound {
+		t.Fatalf("first redirect = %d, want 302", c)
+	}
+	if c := do(); c != http.StatusFound {
+		t.Fatalf("second redirect = %d, want 302", c)
+	}
+	if got := m.redirectCount(handlers.RedirectStoreHit); got != 1 {
+		t.Errorf("RedirectStoreHit = %d, want 1", got)
+	}
+	if got := m.redirectCount(handlers.RedirectCacheHit); got != 1 {
+		t.Errorf("RedirectCacheHit = %d, want 1", got)
+	}
+}
+
+// TestMetrics_RedirectNotFound: an unknown code records a not_found
+// outcome (and the negative-cache path records negative_hit on repeat).
+func TestMetrics_RedirectNotFound(t *testing.T) {
+	t.Parallel()
+	st, cc := newFakeStore(), newFakeCache()
+	m := newFakeMetrics()
+	e := newHandlerWithMetrics(t, st, cc, &scriptedGen{}, m)
+
+	do := func() int {
+		req := httptest.NewRequest(http.MethodGet, "/r/missing", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		return rec.Code
+	}
+	if c := do(); c != http.StatusNotFound {
+		t.Fatalf("first redirect = %d, want 404", c)
+	}
+	if c := do(); c != http.StatusNotFound {
+		t.Fatalf("second redirect = %d, want 404", c)
+	}
+	if got := m.redirectCount(handlers.RedirectNotFound); got != 1 {
+		t.Errorf("RedirectNotFound = %d, want 1", got)
+	}
+	if got := m.redirectCount(handlers.RedirectNegativeHit); got != 1 {
+		t.Errorf("RedirectNegativeHit = %d, want 1", got)
+	}
+}
+
+// TestMetrics_NilMetricsIsNoop: constructing without a Metrics must not
+// panic when a handler path fires an observation (the default no-op).
+func TestMetrics_NilMetricsIsNoop(t *testing.T) {
+	t.Parallel()
+	st, cc := newFakeStore(), newFakeCache()
+	e := newHandlerWithMetrics(t, st, cc, &scriptedGen{codes: []string{"noop123"}}, nil)
+
+	rec, body := doJSON(t, e, http.MethodPost, "/api/v1/links",
+		`{"target_url":"https://example.com"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", rec.Code, string(body))
+	}
+}

--- a/internal/server/business_metrics.go
+++ b/internal/server/business_metrics.go
@@ -1,0 +1,82 @@
+package server
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/vancanhuit/url-shortener/internal/handlers"
+)
+
+// businessMetrics is the Prometheus-backed implementation of
+// handlers.Metrics plus the rate-limit rejection counter. It is held by
+// the server so the same registry exposes RED, Go runtime, pool, and
+// business metrics from a single /metrics endpoint.
+type businessMetrics struct {
+	shorten        *prometheus.CounterVec
+	redirect       *prometheus.CounterVec
+	codeCollisions prometheus.Counter
+	rateLimited    prometheus.Counter
+}
+
+// newBusinessMetrics allocates and registers the business counters on reg.
+// Label series that are known up front are pre-initialized to 0 so they
+// appear in /metrics (and on dashboards) before the first occurrence.
+func newBusinessMetrics(reg *prometheus.Registry) *businessMetrics {
+	shorten := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "links_shortened_total",
+		Help: "Successful link creations partitioned by outcome (created vs deduped).",
+	}, []string{"outcome"})
+
+	redirect := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "links_redirects_total",
+		Help: "Redirect lookups partitioned by how they resolved.",
+	}, []string{"outcome"})
+
+	codeCollisions := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "links_code_collisions_total",
+		Help: "Auto-generated short-code collisions that triggered a retry.",
+	})
+
+	rateLimited := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "links_rate_limited_total",
+		Help: "Requests rejected by the per-IP create rate limiter (HTTP 429).",
+	})
+
+	reg.MustRegister(shorten, redirect, codeCollisions, rateLimited)
+
+	// Pre-create the known label series so they export as 0.
+	for _, o := range []handlers.ShortenOutcome{handlers.ShortenCreated, handlers.ShortenDeduped} {
+		shorten.WithLabelValues(string(o))
+	}
+	for _, o := range []handlers.RedirectOutcome{
+		handlers.RedirectCacheHit, handlers.RedirectNegativeHit, handlers.RedirectStoreHit,
+		handlers.RedirectNotFound, handlers.RedirectGone, handlers.RedirectError,
+	} {
+		redirect.WithLabelValues(string(o))
+	}
+
+	return &businessMetrics{
+		shorten:        shorten,
+		redirect:       redirect,
+		codeCollisions: codeCollisions,
+		rateLimited:    rateLimited,
+	}
+}
+
+func (m *businessMetrics) IncShorten(o handlers.ShortenOutcome) {
+	m.shorten.WithLabelValues(string(o)).Inc()
+}
+
+func (m *businessMetrics) IncRedirect(o handlers.RedirectOutcome) {
+	m.redirect.WithLabelValues(string(o)).Inc()
+}
+
+func (m *businessMetrics) IncCodeCollision() {
+	m.codeCollisions.Inc()
+}
+
+// incRateLimited records one rate-limiter rejection. Kept as a method (not
+// a handlers.Metrics member) because the rejection happens in middleware,
+// not the links handler.
+func (m *businessMetrics) incRateLimited() {
+	m.rateLimited.Inc()
+}

--- a/internal/server/business_metrics_test.go
+++ b/internal/server/business_metrics_test.go
@@ -1,0 +1,117 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/vancanhuit/url-shortener/internal/handlers"
+)
+
+// gatherCounter returns the value of the named counter, optionally
+// filtered to the series carrying the given label values, by gathering
+// from reg. It returns 0 when the series is absent.
+func gatherCounter(t *testing.T, reg *prometheus.Registry, name string, wantLabels map[string]string) float64 {
+	t.Helper()
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			if metricMatchesLabels(m, wantLabels) {
+				return m.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+func metricMatchesLabels(m *dto.Metric, want map[string]string) bool {
+	for k, v := range want {
+		found := false
+		for _, lp := range m.GetLabel() {
+			if lp.GetName() == k && lp.GetValue() == v {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// TestBusinessMetrics_PreInitializesSeries verifies the known label
+// series export at 0 before any observation, so dashboards don't show
+// gaps for outcomes that haven't happened yet.
+func TestBusinessMetrics_PreInitializesSeries(t *testing.T) {
+	t.Parallel()
+	reg := prometheus.NewRegistry()
+	newBusinessMetrics(reg)
+
+	for _, o := range []handlers.ShortenOutcome{handlers.ShortenCreated, handlers.ShortenDeduped} {
+		if v := gatherCounter(t, reg, "links_shortened_total", map[string]string{"outcome": string(o)}); v != 0 {
+			t.Errorf("links_shortened_total{outcome=%q} = %v, want 0", o, v)
+		}
+	}
+	for _, o := range []handlers.RedirectOutcome{
+		handlers.RedirectCacheHit, handlers.RedirectNegativeHit, handlers.RedirectStoreHit,
+		handlers.RedirectNotFound, handlers.RedirectGone, handlers.RedirectError,
+	} {
+		if v := gatherCounter(t, reg, "links_redirects_total", map[string]string{"outcome": string(o)}); v != 0 {
+			t.Errorf("links_redirects_total{outcome=%q} = %v, want 0", o, v)
+		}
+	}
+}
+
+// TestBusinessMetrics_Increments verifies each Inc* method advances the
+// right series, satisfying the handlers.Metrics contract.
+func TestBusinessMetrics_Increments(t *testing.T) {
+	t.Parallel()
+	reg := prometheus.NewRegistry()
+	var m handlers.Metrics = newBusinessMetrics(reg)
+
+	m.IncShorten(handlers.ShortenCreated)
+	m.IncShorten(handlers.ShortenCreated)
+	m.IncShorten(handlers.ShortenDeduped)
+	m.IncRedirect(handlers.RedirectStoreHit)
+	m.IncRedirect(handlers.RedirectGone)
+	m.IncCodeCollision()
+
+	if v := gatherCounter(t, reg, "links_shortened_total", map[string]string{"outcome": "created"}); v != 2 {
+		t.Errorf("shortened created = %v, want 2", v)
+	}
+	if v := gatherCounter(t, reg, "links_shortened_total", map[string]string{"outcome": "deduped"}); v != 1 {
+		t.Errorf("shortened deduped = %v, want 1", v)
+	}
+	if v := gatherCounter(t, reg, "links_redirects_total", map[string]string{"outcome": "store_hit"}); v != 1 {
+		t.Errorf("redirect store_hit = %v, want 1", v)
+	}
+	if v := gatherCounter(t, reg, "links_redirects_total", map[string]string{"outcome": "gone"}); v != 1 {
+		t.Errorf("redirect gone = %v, want 1", v)
+	}
+	if v := gatherCounter(t, reg, "links_code_collisions_total", nil); v != 1 {
+		t.Errorf("code collisions = %v, want 1", v)
+	}
+}
+
+// TestBusinessMetrics_RateLimited verifies the middleware-side rejection
+// counter advances independently of the handlers.Metrics surface.
+func TestBusinessMetrics_RateLimited(t *testing.T) {
+	t.Parallel()
+	reg := prometheus.NewRegistry()
+	bm := newBusinessMetrics(reg)
+
+	bm.incRateLimited()
+	bm.incRateLimited()
+
+	if v := gatherCounter(t, reg, "links_rate_limited_total", nil); v != 2 {
+		t.Errorf("rate_limited = %v, want 2", v)
+	}
+}

--- a/internal/server/db_collector.go
+++ b/internal/server/db_collector.go
@@ -1,0 +1,95 @@
+package server
+
+import (
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// poolStatsCollector is a Prometheus collector that surfaces pgxpool
+// statistics on each scrape. It reads stats lazily via statFn so the
+// values are always current at collection time rather than cached.
+//
+// The pool stats are split between gauges (point-in-time pool occupancy)
+// and counters (monotonic lifetime totals). Exposing both lets operators
+// alert on saturation (acquired ≈ max for sustained periods) and on
+// contention (rising canceled/empty acquires).
+type poolStatsCollector struct {
+	statFn func() *pgxpool.Stat
+
+	acquiredConns      *prometheus.Desc
+	constructingConns  *prometheus.Desc
+	idleConns          *prometheus.Desc
+	totalConns         *prometheus.Desc
+	maxConns           *prometheus.Desc
+	newConnsCount      *prometheus.Desc
+	acquireCount       *prometheus.Desc
+	acquireDuration    *prometheus.Desc
+	canceledAcquire    *prometheus.Desc
+	emptyAcquire       *prometheus.Desc
+	maxLifetimeDestroy *prometheus.Desc
+	maxIdleDestroy     *prometheus.Desc
+}
+
+// newPoolStatsCollector builds a collector backed by statFn. statFn is
+// typically store.Pool().Stat.
+func newPoolStatsCollector(statFn func() *pgxpool.Stat) *poolStatsCollector {
+	const ns = "pgxpool"
+	d := func(name, help string) *prometheus.Desc {
+		return prometheus.NewDesc(ns+"_"+name, help, nil, nil)
+	}
+	return &poolStatsCollector{
+		statFn:             statFn,
+		acquiredConns:      d("acquired_conns", "Connections currently in use."),
+		constructingConns:  d("constructing_conns", "Connections currently being established."),
+		idleConns:          d("idle_conns", "Idle connections in the pool."),
+		totalConns:         d("total_conns", "Total connections in the pool (idle + in use + constructing)."),
+		maxConns:           d("max_conns", "Maximum size of the pool."),
+		newConnsCount:      d("new_conns_total", "Total connections established by the pool."),
+		acquireCount:       d("acquire_total", "Total successful connection acquisitions."),
+		acquireDuration:    d("acquire_duration_seconds_total", "Cumulative time spent acquiring connections."),
+		canceledAcquire:    d("canceled_acquire_total", "Acquisitions canceled by context."),
+		emptyAcquire:       d("empty_acquire_total", "Acquisitions that had to wait for a connection."),
+		maxLifetimeDestroy: d("max_lifetime_destroy_total", "Connections destroyed for exceeding MaxConnLifetime."),
+		maxIdleDestroy:     d("max_idle_destroy_total", "Connections destroyed for exceeding MaxConnIdleTime."),
+	}
+}
+
+func (c *poolStatsCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.acquiredConns
+	ch <- c.constructingConns
+	ch <- c.idleConns
+	ch <- c.totalConns
+	ch <- c.maxConns
+	ch <- c.newConnsCount
+	ch <- c.acquireCount
+	ch <- c.acquireDuration
+	ch <- c.canceledAcquire
+	ch <- c.emptyAcquire
+	ch <- c.maxLifetimeDestroy
+	ch <- c.maxIdleDestroy
+}
+
+func (c *poolStatsCollector) Collect(ch chan<- prometheus.Metric) {
+	s := c.statFn()
+	if s == nil {
+		return
+	}
+	g := func(desc *prometheus.Desc, v float64) {
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, v)
+	}
+	ct := func(desc *prometheus.Desc, v float64) {
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.CounterValue, v)
+	}
+	g(c.acquiredConns, float64(s.AcquiredConns()))
+	g(c.constructingConns, float64(s.ConstructingConns()))
+	g(c.idleConns, float64(s.IdleConns()))
+	g(c.totalConns, float64(s.TotalConns()))
+	g(c.maxConns, float64(s.MaxConns()))
+	ct(c.newConnsCount, float64(s.NewConnsCount()))
+	ct(c.acquireCount, float64(s.AcquireCount()))
+	ct(c.acquireDuration, s.AcquireDuration().Seconds())
+	ct(c.canceledAcquire, float64(s.CanceledAcquireCount()))
+	ct(c.emptyAcquire, float64(s.EmptyAcquireCount()))
+	ct(c.maxLifetimeDestroy, float64(s.MaxLifetimeDestroyCount()))
+	ct(c.maxIdleDestroy, float64(s.MaxIdleDestroyCount()))
+}

--- a/internal/server/db_collector_test.go
+++ b/internal/server/db_collector_test.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// TestPoolStatsCollector_Describe verifies every metric descriptor is
+// emitted, which keeps Describe and Collect in sync (a mismatch would
+// trip Prometheus' consistency checks at registration time).
+func TestPoolStatsCollector_Describe(t *testing.T) {
+	t.Parallel()
+	c := newPoolStatsCollector(func() *pgxpool.Stat { return nil })
+
+	ch := make(chan *prometheus.Desc, 32)
+	c.Describe(ch)
+	close(ch)
+
+	const want = 12
+	got := 0
+	for range ch {
+		got++
+	}
+	if got != want {
+		t.Errorf("Describe emitted %d descriptors, want %d", got, want)
+	}
+}
+
+// TestPoolStatsCollector_NilStatIsSafe verifies Collect is a no-op when
+// statFn yields nil (e.g. a pool that hasn't been initialized), rather
+// than panicking on a scrape.
+func TestPoolStatsCollector_NilStatIsSafe(t *testing.T) {
+	t.Parallel()
+	c := newPoolStatsCollector(func() *pgxpool.Stat { return nil })
+
+	ch := make(chan prometheus.Metric, 32)
+	c.Collect(ch)
+	close(ch)
+
+	if n := len(ch); n != 0 {
+		t.Errorf("Collect emitted %d metrics for nil stat, want 0", n)
+	}
+}
+
+// TestPoolStatsCollector_RegistersCleanly verifies the collector passes
+// Prometheus' Describe/Collect consistency validation at registration.
+func TestPoolStatsCollector_RegistersCleanly(t *testing.T) {
+	t.Parallel()
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(newPoolStatsCollector(func() *pgxpool.Stat { return nil })); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+}

--- a/internal/server/ratelimit.go
+++ b/internal/server/ratelimit.go
@@ -33,11 +33,15 @@ const rateLimitKeyPrefix = "ratelimit:create:"
 //
 // Fail-open: a Redis error is logged and the request is allowed through
 // to avoid turning a cache outage into a service outage.
+//
+// onReject, when non-nil, is invoked once per rejected request so the
+// caller can record a metric. It must be safe for concurrent use.
 func buildCreateRateLimiter(
 	cfg config.Config,
 	rl rateLimiter,
 	ipExtractor func(r *http.Request) string,
 	logger *slog.Logger,
+	onReject func(),
 ) []func(http.Handler) http.Handler {
 	if cfg.RateLimitRPS <= 0 {
 		return nil
@@ -69,6 +73,9 @@ func buildCreateRateLimiter(
 			}
 
 			if !allowed {
+				if onReject != nil {
+					onReject()
+				}
 				logger.Info("rate limit exceeded",
 					"identifier", ip,
 					"method", r.Method,

--- a/internal/server/ratelimit_test.go
+++ b/internal/server/ratelimit_test.go
@@ -53,7 +53,7 @@ func TestBuildCreateRateLimiter_DisabledByDefault(t *testing.T) {
 	t.Parallel()
 	cfg := config.Config{} // zero value, RateLimitRPS=0
 	// rl is nil intentionally: the function must return before touching it.
-	if got := buildCreateRateLimiter(cfg, nil, nil, slog.New(slog.DiscardHandler)); got != nil {
+	if got := buildCreateRateLimiter(cfg, nil, nil, slog.New(slog.DiscardHandler), nil); got != nil {
 		t.Errorf("buildCreateRateLimiter(rps=0) = %d middleware, want nil", len(got))
 	}
 }
@@ -65,7 +65,8 @@ func TestBuildCreateRateLimiter_DisabledByDefault(t *testing.T) {
 func TestBuildCreateRateLimiter_DeniesAfterBurst(t *testing.T) {
 	t.Parallel()
 	cfg := config.Config{RateLimitRPS: 1, RateLimitBurst: 2}
-	mws := buildCreateRateLimiter(cfg, newFakeRateLimiter(), nil, slog.New(slog.DiscardHandler))
+	rejects := 0
+	mws := buildCreateRateLimiter(cfg, newFakeRateLimiter(), nil, slog.New(slog.DiscardHandler), func() { rejects++ })
 	if len(mws) != 1 {
 		t.Fatalf("buildCreateRateLimiter mws = %d, want 1", len(mws))
 	}
@@ -113,6 +114,9 @@ func TestBuildCreateRateLimiter_DeniesAfterBurst(t *testing.T) {
 	if !strings.Contains(strings.ToLower(resp.Error), "rate limit") {
 		t.Errorf("error message = %q, want substring 'rate limit'", resp.Error)
 	}
+	if rejects != 1 {
+		t.Errorf("onReject invocations = %d, want 1", rejects)
+	}
 }
 
 // TestBuildCreateRateLimiter_PerIPIsolation: distinct client IPs each
@@ -122,7 +126,7 @@ func TestBuildCreateRateLimiter_DeniesAfterBurst(t *testing.T) {
 func TestBuildCreateRateLimiter_PerIPIsolation(t *testing.T) {
 	t.Parallel()
 	cfg := config.Config{RateLimitRPS: 1, RateLimitBurst: 1}
-	mws := buildCreateRateLimiter(cfg, newFakeRateLimiter(), nil, slog.New(slog.DiscardHandler))
+	mws := buildCreateRateLimiter(cfg, newFakeRateLimiter(), nil, slog.New(slog.DiscardHandler), nil)
 
 	r := chi.NewRouter()
 	r.With(mws...).Post("/x", func(w http.ResponseWriter, _ *http.Request) {
@@ -157,7 +161,7 @@ func TestBuildCreateRateLimiter_PerIPIsolation(t *testing.T) {
 func TestBuildCreateRateLimiter_BurstDerivedFromRPS(t *testing.T) {
 	t.Parallel()
 	cfg := config.Config{RateLimitRPS: 0.25, RateLimitBurst: 0}
-	mws := buildCreateRateLimiter(cfg, newFakeRateLimiter(), nil, slog.New(slog.DiscardHandler))
+	mws := buildCreateRateLimiter(cfg, newFakeRateLimiter(), nil, slog.New(slog.DiscardHandler), nil)
 
 	r := chi.NewRouter()
 	r.With(mws...).Post("/x", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusCreated) })
@@ -179,7 +183,7 @@ func TestBuildCreateRateLimiter_FailOpen(t *testing.T) {
 
 	errRL := &errorRateLimiter{}
 	cfg := config.Config{RateLimitRPS: 1, RateLimitBurst: 1}
-	mws := buildCreateRateLimiter(cfg, errRL, nil, slog.New(slog.DiscardHandler))
+	mws := buildCreateRateLimiter(cfg, errRL, nil, slog.New(slog.DiscardHandler), nil)
 
 	r := chi.NewRouter()
 	hits := 0

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -92,6 +92,10 @@ func New(cfg config.Config, logger *slog.Logger, deps Deps) *Server {
 	reg := newMetricsRegistry()
 	reqTotal, reqDuration := newRequestMetrics(reg)
 	r.Use(buildMetricsMiddleware(reqTotal, reqDuration))
+	// Business counters (shorten/redirect/collision/rate-limit) and the
+	// Postgres connection-pool collector share the same registry.
+	bizMetrics := newBusinessMetrics(reg)
+	reg.MustRegister(newPoolStatsCollector(deps.Store.Pool().Stat))
 	// Cap request bodies before any handler reads them.
 	bodyLimit := cfg.MaxRequestBodyBytes
 	if bodyLimit <= 0 {
@@ -123,10 +127,11 @@ func New(cfg config.Config, logger *slog.Logger, deps Deps) *Server {
 		Generator:        deps.Generator,
 		BaseURL:          cfg.BaseURL,
 		Logger:           logger,
+		Metrics:          bizMetrics,
 		CacheTTL:         cfg.CacheTTL,
 		NegativeCacheTTL: cfg.NegativeCacheTTL,
 	})
-	createMW := buildCreateRateLimiter(cfg, deps.Cache, ipExtractor, logger)
+	createMW := buildCreateRateLimiter(cfg, deps.Cache, ipExtractor, logger, bizMetrics.incRateLimited)
 	links.Mount(r, createMW...)
 
 	// SPA shell + static assets.


### PR DESCRIPTION
## Summary

Adds application-level and database-pool telemetry to the existing `/metrics` registry so operators can observe behaviour and connection-pool saturation directly, rather than inferring it from logs.

## Business counters

`internal/server/business_metrics.go` registers:

- `links_shortened_total{outcome=created|deduped}`
- `links_redirects_total{outcome=cache_hit|negative_hit|store_hit|not_found|gone|error}`
- `links_code_collisions_total`
- `links_rate_limited_total`

Known label series are pre-initialized to `0` so dashboards have no gaps before the first event.

## Handler wiring

The `handlers` package gains a small `Metrics` interface (`metrics.go`) with a no-op default, keeping the package free of any Prometheus dependency. The links handlers emit the appropriate outcome on every shorten, redirect, collision-retry, and rate-limit-reject path. `buildCreateRateLimiter` now takes an `onReject` callback wired to `incRateLimited`.

## Postgres pool stats

`internal/server/db_collector.go` exports `pgxpool.Stat` via a `prometheus.Collector` under the `pgxpool_` namespace (5 gauges + 7 counters), nil-safe before the pool is ready. Alert on sustained `acquired_conns` ≈ `max_conns` (saturation) and rising `empty_acquire_total` (contention).

## Tests

- Handler outcome emission + no-op default (`internal/handlers/metrics_test.go`)
- Series pre-initialization, increments, rate-limit callback (`internal/server/business_metrics_test.go`)
- Collector Describe / nil-safety / registration (`internal/server/db_collector_test.go`)

README documents the endpoint and metric families.

`mise run fmt`, `mise run lint`, and `mise run test` all pass.