### PR TITLE
test(handlers): assert SSRF targets are rejected via the JSON API

### DIFF
--- a/internal/handlers/ssrf_api_test.go
+++ b/internal/handlers/ssrf_api_test.go
@@ -1,0 +1,56 @@
+package handlers_test
+
+import (
+	"net/http"
+	"testing"
+
+	openapi "github.com/vancanhuit/url-shortener/api"
+)
+
+// TestCreate_RejectsSSRFTargetsViaAPI exercises the full JSON create path
+// (POST /api/v1/links) to prove that server-side request forgery targets are
+// rejected with 422 validation_failed before any row is written. Unit tests in
+// normalize_internal_test.go already cover validateTargetURL / isPrivateHost in
+// isolation; this test pins the behavior at the API boundary so a future
+// refactor of the handler wiring can't silently let an SSRF target through.
+func TestCreate_RejectsSSRFTargetsViaAPI(t *testing.T) {
+	t.Parallel()
+	targets := []struct {
+		name, url string
+	}{
+		{"ipv4_loopback", "http://127.0.0.1/admin"},
+		{"ipv4_loopback_alt", "http://127.0.0.2/"},
+		{"ipv6_loopback", "http://[::1]/"},
+		{"aws_imds_link_local", "http://169.254.169.254/latest/meta-data/"},
+		{"link_local", "http://169.254.0.1/"},
+		{"rfc1918_10", "http://10.0.0.1/"},
+		{"rfc1918_172", "http://172.16.0.1/"},
+		{"rfc1918_192", "http://192.168.1.1/"},
+		{"carrier_grade_nat", "http://100.64.0.1/"},
+		{"localhost_hostname", "http://localhost/"},
+	}
+	for _, tt := range targets {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			st, cc := newFakeStore(), newFakeCache()
+			e, _ := newHandlerWithCache(t, st, cc, &scriptedGen{codes: []string{"unused0"}})
+
+			body := `{"target_url":"` + tt.url + `"}`
+			rec, out := doJSON(t, e, http.MethodPost, "/api/v1/links", body)
+
+			if rec.Code != http.StatusUnprocessableEntity {
+				t.Fatalf("status = %d, want %d (body=%s)", rec.Code, http.StatusUnprocessableEntity, out)
+			}
+			if got := decodeError(t, out).Code; got != openapi.ErrorResponseCodeValidationFailed {
+				t.Errorf("error code = %q, want %q (body=%s)", got, openapi.ErrorResponseCodeValidationFailed, out)
+			}
+
+			st.mu.Lock()
+			n := len(st.links)
+			st.mu.Unlock()
+			if n != 0 {
+				t.Errorf("store has %d link(s) after rejected SSRF target; want 0", n)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds an API-level guard test that exercises the full JSON create path (`POST /api/v1/links`) and asserts that server-side request forgery targets are rejected with `422 validation_failed` before any row is written.

## Coverage

The table covers:

- IPv4 loopback (`127.0.0.1`, `127.0.0.2`)
- IPv6 loopback (`[::1]`)
- AWS IMDS link-local (`169.254.169.254`) and general link-local
- RFC-1918 private (`10/8`, `172.16/12`, `192.168/16`)
- Carrier-grade NAT (`100.64/10`)
- The `localhost` hostname

Each case asserts the `422` status, the `validation_failed` error code, and that the fake store holds zero links afterwards.

## Why

`validateTargetURL` / `isPrivateHost` already have unit coverage in `normalize_internal_test.go`, but nothing pinned the protection at the handler boundary. This test ensures a future refactor of the create wiring can't silently let an SSRF target through.

`mise run fmt`, `mise run lint`, and `mise run test` all pass.